### PR TITLE
fix trainer when dataloader not has batch_sampler

### DIFF
--- a/deepspeech/training/trainer.py
+++ b/deepspeech/training/trainer.py
@@ -181,7 +181,7 @@ class Trainer():
         """Reset the train loader seed and increment `epoch`.
         """
         self.epoch += 1
-        if self.parallel:
+        if self.parallel and hasattr(self.train_loader, "batch_sampler"):
             self.train_loader.batch_sampler.set_epoch(self.epoch)
 
     def train(self):
@@ -191,7 +191,7 @@ class Trainer():
             # save init model, i.e. 0 epoch
             self.save(tag='init', infos=None)
         self.lr_scheduler.step(self.epoch)
-        if self.parallel:
+        if self.parallel and hasattr(self.train_loader, "batch_sampler"):
             self.train_loader.batch_sampler.set_epoch(self.epoch)
 
         logger.info(f"Train Total Examples: {len(self.train_loader.dataset)}")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix trainer when dataloader not has batch_sampler