### PR TITLE
fix the ctc.cpp bug

### DIFF
--- a/deepspeech/decoders/swig/ctc_beam_search_decoder.cpp
+++ b/deepspeech/decoders/swig/ctc_beam_search_decoder.cpp
@@ -28,7 +28,7 @@
 #include "path_trie.h"
 
 using FSTMATCH = fst::SortedMatcher<fst::StdVectorFst>;
-constexpr kSPACE = "<space>"
+const std::string kSPACE = "<space>";
 
 std::vector<std::pair<double, std::string>> ctc_beam_search_decoder(
     const std::vector<std::vector<double>> &probs_seq,


### PR DESCRIPTION

### PR types
Bug fixes

### PR changes
Others

### Describe
constexptr std::string不能使用，原因似乎是是编译期间string类型不构造
