### PR TITLE
resume not increase epoch and step, before_train do it

### DIFF
--- a/deepspeech/training/trainer.py
+++ b/deepspeech/training/trainer.py
@@ -199,8 +199,8 @@ class Trainer():
         if infos:
             # just restore ckpt
             # lr will resotre from optimizer ckpt
-            self.iteration = infos["step"] + 1
-            self.epoch = infos["epoch"] + 1
+            self.iteration = infos["step"]
+            self.epoch = infos["epoch"]
             scratch = False
             logger.info(
                 f"Restore ckpt: epoch {self.epoch }, step {self.iteration}!")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
resume not increase epoch and step, before_train do it