### PR TITLE
fix docs install

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,11 +20,6 @@ formats: []
 python:
   version: 3.7
   install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - doc
-    
     - requirements: docs/requirements.txt
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 myst-parser
+numpydoc
 recommonmark>=0.5.0
 sphinx
 sphinx-autobuild

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,13 +20,9 @@
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-import os
-import sys
-
 import recommonmark.parser
 import sphinx_rtd_theme
 
-sys.path.insert(0, os.path.abspath('../..'))
 autodoc_mock_imports = ["soundfile", "librosa"]
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
fix .readthedocs.yml to let readthedocs build, the older one have to run setup.py and failed when run `apt update -y`