### PR TITLE
[CLI]set default encoding utf8

### DIFF
--- a/paddlespeech/cli/__init__.py
+++ b/paddlespeech/cli/__init__.py
@@ -11,9 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import _locale
 from .asr import ASRExecutor
 from .base_commands import BaseCommand
 from .base_commands import HelpCommand
 from .cls import CLSExecutor
 from .st import STExecutor
 from .tts import TTSExecutor
+
+_locale._getdefaultlocale = (lambda *args: ['en_US', 'utf8'])


### PR DESCRIPTION
### PR types
Others

### PR changes


### Describe
针对win默认使用gbk编码的问题，统一设置cli默认读取文件的encoding为utf8，
