### PR TITLE
fix csmsc fastspeech2 model path

### DIFF
--- a/examples/csmsc/tts3/local/synthesize.sh
+++ b/examples/csmsc/tts3/local/synthesize.sh
@@ -8,7 +8,7 @@ FLAGS_allocator_strategy=naive_best_fit \
 FLAGS_fraction_of_gpu_memory_to_use=0.01 \
 python3 ${BIN_DIR}/synthesize.py \
   --fastspeech2-config=${config_path} \
-  --fastspeech2-checkpoint=${train_output_path}/checkpoints/${ckpt_name} \
+  --fastspeech2-checkpoint=${train_output_path}/${ckpt_name} \
   --fastspeech2-stat=dump/train/speech_stats.npy \
   --pwg-config=pwg_baker_ckpt_0.4/pwg_default.yaml \
   --pwg-checkpoint=pwg_baker_ckpt_0.4/pwg_snapshot_iter_400000.pdz \

--- a/examples/csmsc/tts3/local/synthesize_e2e.sh
+++ b/examples/csmsc/tts3/local/synthesize_e2e.sh
@@ -8,7 +8,7 @@ FLAGS_allocator_strategy=naive_best_fit \
 FLAGS_fraction_of_gpu_memory_to_use=0.01 \
 python3 ${BIN_DIR}/synthesize_e2e.py \
   --fastspeech2-config=${config_path} \
-  --fastspeech2-checkpoint=${train_output_path}/checkpoints/${ckpt_name} \
+  --fastspeech2-checkpoint=${train_output_path}/${ckpt_name} \
   --fastspeech2-stat=dump/train/speech_stats.npy \
   --pwg-config=pwg_baker_ckpt_0.4/pwg_default.yaml \
   --pwg-checkpoint=pwg_baker_ckpt_0.4/pwg_snapshot_iter_400000.pdz \


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
在examples/csmsc/tts3/中，根据最新的fastspeech2_nosil_baker_ckpt_0.4模型文件夹结构，路径里没有checkpoints这一个文件夹，所以在shell中移除。
