### PR TITLE
Fix a bug when sentence inputed contain English words

### DIFF
--- a/paddlespeech/t2s/frontend/zh_frontend.py
+++ b/paddlespeech/t2s/frontend/zh_frontend.py
@@ -105,6 +105,8 @@ class Frontend():
         phones_list = []
         for seg in segments:
             phones = []
+            # Replace all English words in the sentence
+            seg = re.sub('[a-zA-Z]+','',seg)
             seg_cut = psg.lcut(seg)
             initials = []
             finals = []


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types: Bug fixes
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes: APIs
<!-- One of [ Models | APIs | Docs | Others ] -->

### Describe
<!-- Describe what this PR does -->
When sentence inputed contain English words, like "今年8月新增投产1.5GWh", it will cause an error. So we need to filter all English words in sentence.