### PR TITLE
fix speaker id bug in fastspeech2.py

### DIFF
--- a/paddlespeech/t2s/models/fastspeech2/fastspeech2.py
+++ b/paddlespeech/t2s/models/fastspeech2/fastspeech2.py
@@ -940,7 +940,7 @@ class StyleFastSpeech2Inference(FastSpeech2Inference):
         Tensor
             Output sequence of features (L, odim).
         """
-        if spk_id:
+        if spk_id != None:
             spk_id = paddle.to_tensor(spk_id)
         normalized_mel, d_outs, p_outs, e_outs = self.acoustic_model.inference(
             text,


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Models

### Describe
修复了如果spk_id为0，条件判断为False所导致的bug。
