### PR TITLE
[TTS]init for all works in train.py when ngpu>1

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -62,9 +62,3 @@ Contents
    :caption: Acknowledgement
 
    asr/reference
-
-
-
-
-
-

--- a/paddlespeech/t2s/exps/fastspeech2/train.py
+++ b/paddlespeech/t2s/exps/fastspeech2/train.py
@@ -160,9 +160,8 @@ def train_sp(args, config):
     if dist.get_rank() == 0:
         trainer.extend(evaluator, trigger=(1, "epoch"))
         trainer.extend(VisualDL(output_dir), trigger=(1, "iteration"))
-        trainer.extend(
-            Snapshot(max_size=config.num_snapshots), trigger=(1, 'epoch'))
-    # print(trainer.extensions)
+    trainer.extend(
+        Snapshot(max_size=config.num_snapshots), trigger=(1, 'epoch'))
     trainer.run()
 
 

--- a/paddlespeech/t2s/exps/gan_vocoder/hifigan/train.py
+++ b/paddlespeech/t2s/exps/gan_vocoder/hifigan/train.py
@@ -231,9 +231,9 @@ def train_sp(args, config):
         trainer.extend(
             evaluator, trigger=(config.eval_interval_steps, 'iteration'))
         trainer.extend(VisualDL(output_dir), trigger=(1, 'iteration'))
-        trainer.extend(
-            Snapshot(max_size=config.num_snapshots),
-            trigger=(config.save_interval_steps, 'iteration'))
+    trainer.extend(
+        Snapshot(max_size=config.num_snapshots),
+        trigger=(config.save_interval_steps, 'iteration'))
 
     print("Trainer Done!")
     trainer.run()

--- a/paddlespeech/t2s/exps/gan_vocoder/multi_band_melgan/train.py
+++ b/paddlespeech/t2s/exps/gan_vocoder/multi_band_melgan/train.py
@@ -219,9 +219,9 @@ def train_sp(args, config):
         trainer.extend(
             evaluator, trigger=(config.eval_interval_steps, 'iteration'))
         trainer.extend(VisualDL(output_dir), trigger=(1, 'iteration'))
-        trainer.extend(
-            Snapshot(max_size=config.num_snapshots),
-            trigger=(config.save_interval_steps, 'iteration'))
+    trainer.extend(
+        Snapshot(max_size=config.num_snapshots),
+        trigger=(config.save_interval_steps, 'iteration'))
 
     print("Trainer Done!")
     trainer.run()

--- a/paddlespeech/t2s/exps/gan_vocoder/parallelwave_gan/train.py
+++ b/paddlespeech/t2s/exps/gan_vocoder/parallelwave_gan/train.py
@@ -194,11 +194,10 @@ def train_sp(args, config):
         trainer.extend(
             evaluator, trigger=(config.eval_interval_steps, 'iteration'))
         trainer.extend(VisualDL(output_dir), trigger=(1, 'iteration'))
-        trainer.extend(
-            Snapshot(max_size=config.num_snapshots),
-            trigger=(config.save_interval_steps, 'iteration'))
+    trainer.extend(
+        Snapshot(max_size=config.num_snapshots),
+        trigger=(config.save_interval_steps, 'iteration'))
 
-    # print(trainer.extensions.keys())
     print("Trainer Done!")
     trainer.run()
 

--- a/paddlespeech/t2s/exps/gan_vocoder/style_melgan/train.py
+++ b/paddlespeech/t2s/exps/gan_vocoder/style_melgan/train.py
@@ -212,9 +212,9 @@ def train_sp(args, config):
         trainer.extend(
             evaluator, trigger=(config.eval_interval_steps, 'iteration'))
         trainer.extend(VisualDL(output_dir), trigger=(1, 'iteration'))
-        trainer.extend(
-            Snapshot(max_size=config.num_snapshots),
-            trigger=(config.save_interval_steps, 'iteration'))
+    trainer.extend(
+        Snapshot(max_size=config.num_snapshots),
+        trigger=(config.save_interval_steps, 'iteration'))
 
     print("Trainer Done!")
     trainer.run()

--- a/paddlespeech/t2s/exps/speedyspeech/train.py
+++ b/paddlespeech/t2s/exps/speedyspeech/train.py
@@ -171,8 +171,8 @@ def train_sp(args, config):
     if dist.get_rank() == 0:
         trainer.extend(evaluator, trigger=(1, "epoch"))
         trainer.extend(VisualDL(output_dir), trigger=(1, "iteration"))
-        trainer.extend(
-            Snapshot(max_size=config.num_snapshots), trigger=(1, 'epoch'))
+    trainer.extend(
+        Snapshot(max_size=config.num_snapshots), trigger=(1, 'epoch'))
     trainer.run()
 
 

--- a/paddlespeech/t2s/exps/tacotron2/train.py
+++ b/paddlespeech/t2s/exps/tacotron2/train.py
@@ -155,9 +155,8 @@ def train_sp(args, config):
     if dist.get_rank() == 0:
         trainer.extend(evaluator, trigger=(1, "epoch"))
         trainer.extend(VisualDL(output_dir), trigger=(1, "iteration"))
-        trainer.extend(
-            Snapshot(max_size=config.num_snapshots), trigger=(1, 'epoch'))
-    # print(trainer.extensions)
+    trainer.extend(
+        Snapshot(max_size=config.num_snapshots), trigger=(1, 'epoch'))
     trainer.run()
 
 

--- a/paddlespeech/t2s/exps/transformer_tts/train.py
+++ b/paddlespeech/t2s/exps/transformer_tts/train.py
@@ -148,9 +148,8 @@ def train_sp(args, config):
     if dist.get_rank() == 0:
         trainer.extend(evaluator, trigger=(1, "epoch"))
         trainer.extend(VisualDL(output_dir), trigger=(1, "iteration"))
-        trainer.extend(
-            Snapshot(max_size=config.num_snapshots), trigger=(1, 'epoch'))
-    # print(trainer.extensions)
+    trainer.extend(
+        Snapshot(max_size=config.num_snapshots), trigger=(1, 'epoch'))
     trainer.run()
 
 

--- a/paddlespeech/t2s/exps/wavernn/train.py
+++ b/paddlespeech/t2s/exps/wavernn/train.py
@@ -168,9 +168,9 @@ def train_sp(args, config):
         trainer.extend(
             evaluator, trigger=(config.eval_interval_steps, 'iteration'))
         trainer.extend(VisualDL(output_dir), trigger=(1, 'iteration'))
-        trainer.extend(
-            Snapshot(max_size=config.num_snapshots),
-            trigger=(config.save_interval_steps, 'iteration'))
+    trainer.extend(
+        Snapshot(max_size=config.num_snapshots),
+        trigger=(config.save_interval_steps, 'iteration'))
 
     print("Trainer Done!")
     trainer.run()

--- a/paddlespeech/text/exps/ernie_linear/train.py
+++ b/paddlespeech/text/exps/ernie_linear/train.py
@@ -135,9 +135,8 @@ def train_sp(args, config):
     if dist.get_rank() == 0:
         trainer.extend(evaluator, trigger=(1, "epoch"))
         trainer.extend(VisualDL(output_dir), trigger=(1, "iteration"))
-        trainer.extend(
-            Snapshot(max_size=config.num_snapshots), trigger=(1, 'epoch'))
-    # print(trainer.extensions)
+    trainer.extend(
+        Snapshot(max_size=config.num_snapshots), trigger=(1, 'epoch'))
     trainer.run()
 
 


### PR DESCRIPTION
When continuing training from pretrained models and ngpu>1, we must init the model with pretrained model for all workers, we only init for worker_0 before.. 