### PR TITLE
[TTS] fix Speedyspeech multi-speaker inference, test=tts

### DIFF
--- a/paddlespeech/t2s/exps/synthesize_e2e.py
+++ b/paddlespeech/t2s/exps/synthesize_e2e.py
@@ -194,10 +194,10 @@ def evaluate(args):
                 am_inference = jit.to_static(
                     am_inference,
                     input_spec=[
-                        InputSpec([-1], dtype=paddle.int64),  # text
-                        InputSpec([-1], dtype=paddle.int64),  # tone
-                        None,  # duration
-                        InputSpec([-1], dtype=paddle.int64)  # spk_id
+                        InputSpec([-1], dtype=paddle.int64), # text
+                        InputSpec([-1], dtype=paddle.int64), # tone
+                        InputSpec([1], dtype=paddle.int64),  # spk_id
+                        None                                 # duration
                     ])
             else:
                 am_inference = jit.to_static(

--- a/paddlespeech/t2s/models/speedyspeech/speedyspeech.py
+++ b/paddlespeech/t2s/models/speedyspeech/speedyspeech.py
@@ -247,7 +247,7 @@ class SpeedySpeechInference(nn.Layer):
         self.normalizer = normalizer
         self.acoustic_model = speedyspeech_model
 
-    def forward(self, phones, tones, durations=None, spk_id=None):
+    def forward(self, phones, tones, spk_id=None, durations=None):
         normalized_mel = self.acoustic_model.inference(
             phones, tones, durations=durations, spk_id=spk_id)
         logmel = self.normalizer.inverse(normalized_mel)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Models

### Describe
把Speedyspeech中inference的durations参数放到最后，原因是synthesize_e2e.py预测时
```python
mel = am_inference(part_phone_ids, part_tone_ids, spk_id)
```
这行代码的spk_id会被认为是durations，而如果加入None则动转静会报错。
```python
mel = am_inference(part_phone_ids, part_tone_ids, None, spk_id)
```
PS：我不知道为啥之前可以成功导出静态模型，可能用的不是这个代码。
