### PR TITLE
[Speechx]fix normalizer bug

### DIFF
--- a/speechx/speechx/frontend/normalizer.cc
+++ b/speechx/speechx/frontend/normalizer.cc
@@ -107,7 +107,7 @@ void CMVN::Accept(const kaldi::VectorBase<kaldi::BaseFloat>& inputs) {
 }
 
 bool CMVN::Read(kaldi::Vector<BaseFloat>* feats) {
-    if (base_extractor_->Read(feats) == false) {
+    if (base_extractor_->Read(feats) == false || feats->Dim() == 0) {
         return false;
     }
     Compute(feats);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Describe
<!-- Describe what this PR does -->
fix normalizer bug,, when the feat.Dim()==0, the read function should return false.