### PR TITLE
[TTS Clinet] fix client Parameter : sample rate not work

### DIFF
--- a/paddlespeech/server/utils/audio_handler.py
+++ b/paddlespeech/server/utils/audio_handler.py
@@ -447,6 +447,7 @@ class TTSHttpHandler:
             sample_rate (int, optional): audio sample rate, 0 means the same as model. Defaults to 0.
             output (str, optional): save audio path. Defaults to None.
         """
+        sample_rate = 24000 if sample_rate == 0 else sample_rate
         # 1. Create request
         params = {
             "text": text,
@@ -482,14 +483,14 @@ class TTSHttpHandler:
                     self.t.start()
                     self.start_play = False
             all_bytes += audio
-            chunk_duration_list.append(len(audio) / 2.0 / 24000)
+            chunk_duration_list.append(len(audio) / 2.0 / sample_rate)
 
         final_response = time.time() - st
-        duration = len(all_bytes) / 2.0 / 24000
+        duration = len(all_bytes) / 2.0 / sample_rate
         html.close()  # when stream=True
 
         if output is not None:
-            save_audio_success = save_audio(all_bytes, output)
+            save_audio_success = save_audio(all_bytes, output, sample_rate=sample_rate)
         else:
             save_audio_success = False
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Describe
<!-- Describe what this PR does -->
当我使用8k的模型来运行server clinet的时候发现了并不能生成8k的音频
于是发生了修改