### PR TITLE
fix: dockerfile cpu

### DIFF
--- a/docker/ubuntu18-cpu/Dockerfile
+++ b/docker/ubuntu18-cpu/Dockerfile
@@ -1,15 +1,17 @@
 FROM registry.baidubce.com/paddlepaddle/paddle:2.2.2
 LABEL maintainer="paddlesl@baidu.com"
 
+RUN apt-get update \
+  && apt-get install libsndfile-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN git clone --depth 1 https://github.com/PaddlePaddle/PaddleSpeech.git /home/PaddleSpeech  
 RUN pip3 uninstall mccabe -y ; exit 0;
 RUN pip3 install multiprocess==0.70.12 importlib-metadata==4.2.0 dill==0.3.4
 
-RUN cd /home/PaddleSpeech/audio
-RUN python setup.py bdist_wheel
-
-RUN cd /home/PaddleSpeech
-RUN python setup.py bdist_wheel
-RUN pip install audio/dist/*.whl dist/*.whl
-
 WORKDIR /home/PaddleSpeech/
+RUN python setup.py bdist_wheel
+RUN pip install dist/*.whl -i https://pypi.tuna.tsinghua.edu.cn/simple
+
+CMD ['bash']


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes: Others
<!-- One of [ Models | APIs | Docs | Others ] -->
Fix issues from `docker/ubuntu18-cpu/Dockerfile`

### Describe
I try to build docker image to run paddlespeech_server. I found two problem when build image.
1. No folder `audio` anymore.
2. Missing dependency `libsndfile-dev`
This PR fix these.