### PR TITLE
[setup]fix version of onnxruntime

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,7 +18,7 @@ librosa==0.8.1
 loguru
 matplotlib
 nara_wpe
-onnxruntime
+onnxruntime-gpu==1.10.0
 pandas
 paddlenlp
 paddlespeech_feat

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,7 +18,7 @@ librosa==0.8.1
 loguru
 matplotlib
 nara_wpe
-onnxruntime-gpu==1.10.0
+onnxruntime==1.10.0
 pandas
 paddlenlp
 paddlespeech_feat

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ base = [
     "loguru",
     "matplotlib",
     "nara_wpe",
-    "onnxruntime-gpu==1.10.0",
+    "onnxruntime==1.10.0",
     "pandas",
     "paddlenlp",
     "paddlespeech_feat",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ base = [
     "loguru",
     "matplotlib",
     "nara_wpe",
-    "onnxruntime",
+    "onnxruntime-gpu==1.10.0",
     "pandas",
     "paddlenlp",
     "paddlespeech_feat",


### PR DESCRIPTION
to fix the following bug:
<img width="767" alt="beb5b506e84c4c142932958fe01953df" src="https://user-images.githubusercontent.com/24568452/182553728-e7c25a49-4877-4f58-b093-0fb501e3fd3e.png">

if install `onnxruntime`, you can only use cpu

if install `onnxruntime-gpu`, if your cuda version is all right (check https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html), you can use `gpu`, or, even you set the device to `gpu`, you can only use `cpu`, see: https://zhuanlan.zhihu.com/p/492040015

As for MAC, you can only install `onnxruntime`, so we install `onnxruntime` by default, if you want to use gpu for onnxruntime inference, please install `onnxruntime-gpu`, and set device for onnxruntime to gpu

**As for GPU, onnxruntime is not as fast as Paddle Dynamic Graph and PaddleInference for TTS models**