### PR TITLE
[TTS]fix dygraph to static for tacotron2, test=doc

### DIFF
--- a/paddlespeech/t2s/modules/tacotron2/attentions.py
+++ b/paddlespeech/t2s/modules/tacotron2/attentions.py
@@ -124,7 +124,7 @@ class AttLoc(nn.Layer):
             dec_z,
             att_prev,
             scaling=2.0,
-            last_attended_idx=None,
+            last_attended_idx=-1,
             backward_window=1,
             forward_window=3, ):
         """Calculate AttLoc forward propagation.

--- a/paddlespeech/t2s/modules/tacotron2/attentions.py
+++ b/paddlespeech/t2s/modules/tacotron2/attentions.py
@@ -194,7 +194,7 @@ class AttLoc(nn.Layer):
 
         e = masked_fill(e, self.mask, -float("inf"))
         # apply monotonic attention constraint (mainly for TTS)
-        if last_attended_idx is not None:
+        if last_attended_idx != -1:
             e = _apply_attention_constraint(e, last_attended_idx,
                                             backward_window, forward_window)
 

--- a/paddlespeech/t2s/modules/tacotron2/attentions.py
+++ b/paddlespeech/t2s/modules/tacotron2/attentions.py
@@ -47,11 +47,13 @@ def _apply_attention_constraint(e,
         https://arxiv.org/abs/1710.07654
 
     """
-    if paddle.shape(e)[0] != 1:
-        raise NotImplementedError(
-            "Batch attention constraining is not yet supported.")
-    backward_idx = last_attended_idx - backward_window
-    forward_idx = last_attended_idx + forward_window
+    # for dygraph to static graph
+    # if e.shape[0] != 1:
+    #     raise NotImplementedError(
+    #         "Batch attention constraining is not yet supported.")
+    backward_idx = paddle.cast(
+        last_attended_idx - backward_window, dtype='int64')
+    forward_idx = paddle.cast(last_attended_idx + forward_window, dtype='int64')
     if backward_idx > 0:
         e[:, :backward_idx] = -float("inf")
     if forward_idx < paddle.shape(e)[1]:

--- a/paddlespeech/t2s/modules/tacotron2/decoder.py
+++ b/paddlespeech/t2s/modules/tacotron2/decoder.py
@@ -562,7 +562,7 @@ class Decoder(nn.Layer):
         idx = 0
         outs, att_ws, probs = [], [], []
         prob = paddle.zeros([1])
-        while True:
+        while paddle.to_tensor(True):
             # updated index
             idx += self.reduction_factor
 

--- a/paddlespeech/t2s/modules/tacotron2/decoder.py
+++ b/paddlespeech/t2s/modules/tacotron2/decoder.py
@@ -556,13 +556,15 @@ class Decoder(nn.Layer):
         if use_att_constraint:
             last_attended_idx = 0
         else:
-            last_attended_idx = None
+            last_attended_idx = -1
 
         # loop for an output sequence
         idx = 0
         outs, att_ws, probs = [], [], []
         prob = paddle.zeros([1])
         while paddle.to_tensor(True):
+            z_list = z_list
+            c_list = c_list
             # updated index
             idx += self.reduction_factor
 


### PR DESCRIPTION
```
git clone PaddleSpeech
cd PaddleSpeech
# 安装依赖，安装过了可忽略
pip install . 
cd examples/csmsc/tts0
wget https://paddlespeech.bj.bcebos.com/Parakeet/released_models/pwgan/pwg_baker_ckpt_0.4.zip
unzip pwg_baker_ckpt_0.4.zip
wget https://paddlespeech.bj.bcebos.com/Parakeet/released_models/tacotron2/tacotron2_csmsc_ckpt_0.2.0.zip
unzip tacotron2_csmsc_ckpt_0.2.0.zip
mkdir -p dump/train
mkdir -p exp/default/checkpoints
cp tacotron2_csmsc_ckpt_0.2.0/snapshot_iter_30600.pdz exp/default/checkpoints
cp tacotron2_csmsc_ckpt_0.2.0/speech_stats.npy dump/train
cp tacotron2_csmsc_ckpt_0.2.0/phone_id_map.txt dump/
vim run.sh
修改 ckpt_name=snapshot_iter_30600.pdz
# 执行动转静并 load 之后进行推理
# 如果想要仅执行动态图推理，不执行动转静，注释掉 local/synthesize_e2e.sh 28 行和 27 行最后的 "\"
./run.sh --stage 3 --stop-stage 3
# 生成的静态图模型在 ./exp/default/inference
# stage 3 执行后生成的音频在 ./exp/default/test_e2e
# 静态图推理
./run.sh --stage 4 --stop-stage 4
# stage 4 执行后生成的音频在 ./exp/default/pd_infer_out
python3 -m http.server 8097 开个端口可在网页上听音频
paddle 2.3.2 正常合成，paddle commit：e1a5fb8f653c0c948abcebb3e3e252edd724f05c 合成音频内容不对
```