### PR TITLE
BytesIO类型时，要保证切到初始位置，这样多次读取才能够正常。比如__call__函数。

### DIFF
--- a/paddlespeech/cli/asr/infer.py
+++ b/paddlespeech/cli/asr/infer.py
@@ -40,6 +40,7 @@ from paddlespeech.s2t.utils.utility import UpdateConfig
 
 __all__ = ['ASRExecutor']
 
+
 @timer_register
 class ASRExecutor(BaseExecutor):
     def __init__(self):

--- a/paddlespeech/cli/asr/infer.py
+++ b/paddlespeech/cli/asr/infer.py
@@ -15,7 +15,7 @@ import argparse
 import os
 import sys
 import time
-from io import BytesIO
+import io 
 from collections import OrderedDict
 from typing import List
 from typing import Optional
@@ -230,7 +230,7 @@ class ASRExecutor(BaseExecutor):
         audio_file = input
         if isinstance(audio_file, (str, os.PathLike)):
             logger.debug("Preprocess audio_file:" + audio_file)
-        elif isinstance(audio_file, BytesIO):
+        elif isinstance(audio_file, io.BytesIO):
             audio_file.seek(0)
 
         # Get the object for feature extraction
@@ -355,7 +355,7 @@ class ASRExecutor(BaseExecutor):
             if not os.path.isfile(audio_file):
                 logger.error("Please input the right audio file path")
                 return False
-        elif isinstance(audio_file, BytesIO):
+        elif isinstance(audio_file, io.BytesIO):
             audio_file.seek(0)
 
         logger.debug("checking the audio file format......")

--- a/paddlespeech/cli/asr/infer.py
+++ b/paddlespeech/cli/asr/infer.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import io
 import os
 import sys
 import time
-import io 
 from collections import OrderedDict
 from typing import List
 from typing import Optional

--- a/paddlespeech/cli/asr/infer.py
+++ b/paddlespeech/cli/asr/infer.py
@@ -15,6 +15,7 @@ import argparse
 import os
 import sys
 import time
+from io import BytesIO
 from collections import OrderedDict
 from typing import List
 from typing import Optional
@@ -229,6 +230,8 @@ class ASRExecutor(BaseExecutor):
         audio_file = input
         if isinstance(audio_file, (str, os.PathLike)):
             logger.debug("Preprocess audio_file:" + audio_file)
+        elif isinstance(audio_file, BytesIO):
+            audio_file.seek(0)
 
         # Get the object for feature extraction
         if "deepspeech2" in model_type or "conformer" in model_type or "transformer" in model_type:
@@ -352,6 +355,8 @@ class ASRExecutor(BaseExecutor):
             if not os.path.isfile(audio_file):
                 logger.error("Please input the right audio file path")
                 return False
+        elif isinstance(audio_file, BytesIO):
+            audio_file.seek(0)
 
         logger.debug("checking the audio file format......")
         try:

--- a/paddlespeech/cli/asr/infer.py
+++ b/paddlespeech/cli/asr/infer.py
@@ -40,7 +40,6 @@ from paddlespeech.s2t.utils.utility import UpdateConfig
 
 __all__ = ['ASRExecutor']
 
-
 @timer_register
 class ASRExecutor(BaseExecutor):
     def __init__(self):


### PR DESCRIPTION
__call__函数的参数audio_file为BytesIO类型时执行到self.preprocess(model, audio_file)会报错，需要判断audio_file为BytesIO类型时执行audio_file.seek(0)。

<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Describe
<!-- Describe what this PR does -->
