### PR TITLE
[Server]fix uvicorn's version

### DIFF
--- a/paddlespeech/server/bin/paddlespeech_server.py
+++ b/paddlespeech/server/bin/paddlespeech_server.py
@@ -113,7 +113,7 @@ class ServerExecutor(BaseExecutor):
         """
         config = get_config(config_file)
         if self.init(config):
-            uvicorn.run(app, host=config.host, port=config.port, debug=True)
+            uvicorn.run(app, host=config.host, port=config.port)
 
 
 @cli_server_register(

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ base = [
     "pybind11",
 ]
 
-server = ["fastapi", "uvicorn<=0.18.3", "pattern_singleton", "websockets"]
+server = ["fastapi", "uvicorn", "pattern_singleton", "websockets"]
 
 requirements = {
     "install":

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ base = [
     "pybind11",
 ]
 
-server = ["fastapi", "uvicorn", "pattern_singleton", "websockets"]
+server = ["fastapi", "uvicorn<=0.18.3", "pattern_singleton", "websockets"]
 
 requirements = {
     "install":


### PR DESCRIPTION
in uvicorn 0.19.0, remove `debug`, see https://github.com/encode/uvicorn/issues/1719
so we should use uvicorn<=0.18.3 or remove `debug` in `uvicorn.run()`