### PR TITLE
[server] onnx ds2 need onnxruntime>=1.11.0

### DIFF
--- a/demos/streaming_asr_server/README.md
+++ b/demos/streaming_asr_server/README.md
@@ -1,5 +1,7 @@
 ([简体中文](./README_cn.md)|English)
 
+> conf/ws_ds2_application.yaml need onnxruntime>=1.11.0
+
 # Streaming ASR Server
 
 ## Introduction

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ base = [
     "loguru",
     "matplotlib",
     "nara_wpe",
-    "onnxruntime==1.10.0",
+    "onnxruntime==1.11.0",
     "opencc",
     "pandas",
     "paddlenlp>=2.4.3",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
onnx ds2 need onnxruntime>=1.11.0

#2725