### PR TITLE
fix AttributeError "module 'distutils' has no attribute 'ccompiler'"

### DIFF
--- a/third_party/ctc_decoders/setup.py
+++ b/third_party/ctc_decoders/setup.py
@@ -19,7 +19,8 @@ import os
 import platform
 import sys
 
-from setuptools import distutils
+import setuptools
+from distutils import ccompiler
 from setuptools import Extension
 from setuptools import setup
 
@@ -75,7 +76,7 @@ def compile_test(header, library):
 
 
 # hack compile to support parallel compiling
-distutils.ccompiler.CCompiler.compile = parallelCCompile
+ccompiler.CCompiler.compile = parallelCCompile
 
 FILES = glob.glob('kenlm/util/*.cc') \
     + glob.glob('kenlm/lm/*.cc') \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
fix AttributeError "module 'distutils' has no attribute 'ccompiler'" in `setuptools 65.4.1`
