### PR TITLE
Fix libsndfile.so not found

### DIFF
--- a/docker/ubuntu18-cpu/Dockerfile
+++ b/docker/ubuntu18-cpu/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.baidubce.com/paddlepaddle/paddle:2.2.2
 LABEL maintainer="paddlesl@baidu.com"
 
 RUN apt-get update \
-  && apt-get install libsndfile-dev \
+  && apt-get install libsndfile-dev libsndfile1 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fix libsndfile.so not found

<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Describe
<!-- Describe what this PR does -->
