### PR TITLE
[Install]revise paddlenlp's version

### DIFF
--- a/paddlespeech/text/models/ernie_crf/model.py
+++ b/paddlespeech/text/models/ernie_crf/model.py
@@ -27,7 +27,7 @@ class ErnieCrf(nn.Layer):
                  **kwargs):
         super().__init__()
         self.ernie = ErnieForTokenClassification.from_pretrained(
-            pretrained_token, num_classes=num_classes, **kwargs)
+            pretrained_token, num_labels=num_classes, **kwargs)
         self.num_classes = num_classes
         self.crf = LinearChainCrf(
             self.num_classes, crf_lr=crf_lr, with_start_stop_tag=False)

--- a/paddlespeech/text/models/ernie_linear/ernie_linear.py
+++ b/paddlespeech/text/models/ernie_linear/ernie_linear.py
@@ -43,9 +43,9 @@ class ErnieLinear(nn.Layer):
                 num_classes, int
             ) and num_classes > 0, 'Argument `num_classes` must be an integer.'
             self.ernie = ErnieForTokenClassification.from_pretrained(
-                pretrained_token, num_classes=num_classes, **kwargs)
+                pretrained_token, num_labels=num_classes, **kwargs)
 
-        self.num_classes = self.ernie.num_classes
+        self.num_classes = self.ernie.num_labels
         self.softmax = nn.Softmax()
 
     def forward(self,

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ base = [
     "onnxruntime==1.11.0",
     "opencc",
     "pandas",
-    "paddlenlp>=2.4.3, <=2.4.5",
+    "paddlenlp>=2.4.8",
     "paddlespeech_feat",
     "Pillow>=9.0.0",
     "praatio==5.0.0",


### PR DESCRIPTION
in paddlenlp==2.4.7, they remove ernie.num_classes, and mv ernie.num_classes -> ernie.num_labels, which will cause 
<img width="1104" alt="c875875afe016b36bca225b9e0440490" src="https://user-images.githubusercontent.com/24568452/209622465-647ef572-2ea1-40d6-be85-cfc59a8e635b.png">
in paddlenlp==2.4.8, they make backward compatibility of ernie.num_classes, but  in the long run, ernie.num_classes will be deleted, so we rename ernie.num_classes to ernie.num_labels and dependent on paddlenlp>=2.4.8
