### PR TITLE
[Install]remove utils and third_party in paddlespeech's site-packages

### DIFF
--- a/audio/setup.py
+++ b/audio/setup.py
@@ -273,7 +273,7 @@ def main():
         },
 
         # Package info
-        packages=find_packages(include=('paddleaudio*')),
+        packages=find_packages(include=['paddleaudio*']),
         package_data=lib_package_data,
         ext_modules=setup_helpers.get_ext_modules(),
         zip_safe=True,

--- a/setup.py
+++ b/setup.py
@@ -300,7 +300,7 @@ setup_info = dict(
     },
 
     # Package info
-    packages=find_packages(include=('paddlespeech*')),
+    packages=find_packages(include=['paddlespeech*'], exclude=['utils', 'third_party']),
     zip_safe=True,
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
If `utils` and `third_party` are installed in python's site-packages, they will be regarded as Python third-party library, which doesn't meet our expectations.

before fix:
![ad2a9f39eb8e649e816db1253585d50f](https://user-images.githubusercontent.com/24568452/215994041-88da9995-f372-4bf0-8295-67167074647d.png)
after fix:
![c377bb5bf93285e710123d144f304ae5](https://user-images.githubusercontent.com/24568452/215994069-eb27b69b-57aa-4252-b2d2-9a5426ba91fd.png)
