### PR TITLE
[TTS]vits dygraph to static

### DIFF
--- a/examples/csmsc/vits/local/synthesize_e2e.sh
+++ b/examples/csmsc/vits/local/synthesize_e2e.sh
@@ -18,5 +18,6 @@ if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
         --phones_dict=dump/phone_id_map.txt \
         --output_dir=${train_output_path}/test_e2e \
         --text=${BIN_DIR}/../sentences.txt \
-        --add-blank=${add_blank}
+        --add-blank=${add_blank} #\
+        # --inference_dir=${train_output_path}/inference
 fi

--- a/examples/csmsc/vits/run.sh
+++ b/examples/csmsc/vits/run.sh
@@ -9,7 +9,7 @@ stop_stage=100
 
 conf_path=conf/default.yaml
 train_output_path=exp/default
-ckpt_name=snapshot_iter_333000.pdz
+ckpt_name=snapshot_iter_153.pdz
 add_blank=true
 
 # with the following command, you can choose the stage range you want to run

--- a/examples/csmsc/vits/run.sh
+++ b/examples/csmsc/vits/run.sh
@@ -9,7 +9,7 @@ stop_stage=100
 
 conf_path=conf/default.yaml
 train_output_path=exp/default
-ckpt_name=snapshot_iter_153.pdz
+ckpt_name=snapshot_iter_333000.pdz
 add_blank=true
 
 # with the following command, you can choose the stage range you want to run

--- a/paddlespeech/t2s/exps/syn_utils.py
+++ b/paddlespeech/t2s/exps/syn_utils.py
@@ -446,8 +446,16 @@ def am_to_static(am_inference,
         am_inference = jit.to_static(
             am_inference, input_spec=[InputSpec([-1], dtype=paddle.int64)])
     elif am_name == 'vits':
-        am_inference = jit.to_static(
-            am_inference, input_spec=[InputSpec([-1], dtype=paddle.int64)])
+        if am_dataset in {"aishell3", "vctk"} and speaker_dict is not None:
+            am_inference = jit.to_static(
+                am_inference,
+                input_spec=[
+                    InputSpec([-1], dtype=paddle.int64),
+                    InputSpec([1], dtype=paddle.int64),
+                ])
+        else:
+            am_inference = jit.to_static(
+                am_inference, input_spec=[InputSpec([-1], dtype=paddle.int64)])
     jit.save(am_inference, os.path.join(inference_dir, am))
     am_inference = jit.load(os.path.join(inference_dir, am))
     return am_inference

--- a/paddlespeech/t2s/exps/syn_utils.py
+++ b/paddlespeech/t2s/exps/syn_utils.py
@@ -445,9 +445,11 @@ def am_to_static(am_inference,
     elif am_name == 'tacotron2':
         am_inference = jit.to_static(
             am_inference, input_spec=[InputSpec([-1], dtype=paddle.int64)])
-
-    paddle.jit.save(am_inference, os.path.join(inference_dir, am))
-    am_inference = paddle.jit.load(os.path.join(inference_dir, am))
+    elif am_name == 'vits':
+        am_inference = jit.to_static(
+            am_inference, input_spec=[InputSpec([-1], dtype=paddle.int64)])
+    jit.save(am_inference, os.path.join(inference_dir, am))
+    am_inference = jit.load(os.path.join(inference_dir, am))
     return am_inference
 
 
@@ -458,8 +460,8 @@ def voc_to_static(voc_inference,
         voc_inference, input_spec=[
             InputSpec([-1, 80], dtype=paddle.float32),
         ])
-    paddle.jit.save(voc_inference, os.path.join(inference_dir, voc))
-    voc_inference = paddle.jit.load(os.path.join(inference_dir, voc))
+    jit.save(voc_inference, os.path.join(inference_dir, voc))
+    voc_inference = jit.load(os.path.join(inference_dir, voc))
     return voc_inference
 
 

--- a/paddlespeech/t2s/exps/vits/synthesize_e2e.py
+++ b/paddlespeech/t2s/exps/vits/synthesize_e2e.py
@@ -64,7 +64,6 @@ def evaluate(args):
     vits = VITS(idim=vocab_size, odim=odim, **config["model"])
     vits.set_state_dict(paddle.load(args.ckpt)["main_params"])
     vits.eval()
-    VITSInference
 
     vits_inference = VITSInference(vits)
     # whether dygraph to static
@@ -108,7 +107,8 @@ def evaluate(args):
                     spk_id = None
                     if spk_num is not None:
                         spk_id = paddle.to_tensor(args.spk_id)
-                    wav = vits_inference(text=part_phone_ids, sids=spk_id)
+                    # wav = vits_inference(text=part_phone_ids, sids=spk_id)
+                    wav = vits_inference(part_phone_ids)
                     if flags == 0:
                         wav_all = wav
                         flags = 1

--- a/paddlespeech/t2s/exps/vits/synthesize_e2e.py
+++ b/paddlespeech/t2s/exps/vits/synthesize_e2e.py
@@ -71,11 +71,6 @@ def evaluate(args):
     vits_inference = VITSInference(vits)
     # whether dygraph to static
     if args.inference_dir:
-        # acoustic model
-        # vits = jit.to_static(
-        #         vits, input_spec=[InputSpec([-1], dtype=paddle.int64)])
-        # jit.save(vits, os.path.join(inference_dir, args.am))
-        # vits = jit.load(os.path.join(inference_dir, args.am))
         vits_inference = am_to_static(
             am_inference=vits_inference,
             am=args.am,
@@ -108,8 +103,8 @@ def evaluate(args):
                 for i in range(len(phone_ids)):
                     part_phone_ids = phone_ids[i]
                     spk_id = None
-                    if am_dataset in {"aishell3", "vctk"
-                                      } and spk_num is not None:
+                    if am_dataset in {"aishell3",
+                                      "vctk"} and spk_num is not None:
                         spk_id = paddle.to_tensor(args.spk_id)
                         wav = vits_inference(part_phone_ids, spk_id)
                     else:

--- a/paddlespeech/t2s/exps/vits/synthesize_e2e.py
+++ b/paddlespeech/t2s/exps/vits/synthesize_e2e.py
@@ -42,6 +42,9 @@ def evaluate(args):
 
     # frontend
     frontend = get_frontend(lang=args.lang, phones_dict=args.phones_dict)
+    # acoustic model
+    am_name = args.am[:args.am.rindex('_')]
+    am_dataset = args.am[args.am.rindex('_') + 1:]
 
     spk_num = None
     if args.speaker_dict is not None:
@@ -78,7 +81,7 @@ def evaluate(args):
             am=args.am,
             inference_dir=args.inference_dir,
             speaker_dict=args.speaker_dict)
-     
+
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     merge_sentences = False
@@ -105,10 +108,12 @@ def evaluate(args):
                 for i in range(len(phone_ids)):
                     part_phone_ids = phone_ids[i]
                     spk_id = None
-                    if spk_num is not None:
+                    if am_dataset in {"aishell3", "vctk"
+                                      } and spk_num is not None:
                         spk_id = paddle.to_tensor(args.spk_id)
-                    # wav = vits_inference(text=part_phone_ids, sids=spk_id)
-                    wav = vits_inference(part_phone_ids)
+                        wav = vits_inference(part_phone_ids, spk_id)
+                    else:
+                        wav = vits_inference(part_phone_ids)
                     if flags == 0:
                         wav_all = wav
                         flags = 1

--- a/paddlespeech/t2s/models/vits/transform.py
+++ b/paddlespeech/t2s/models/vits/transform.py
@@ -35,9 +35,10 @@ def piecewise_rational_quadratic_transform(
         inverse=False,
         tails=None,
         tail_bound=1.0,
-        min_bin_width=DEFAULT_MIN_BIN_WIDTH,
-        min_bin_height=DEFAULT_MIN_BIN_HEIGHT,
-        min_derivative=DEFAULT_MIN_DERIVATIVE, ):
+        # for dygraph-to-static
+        min_bin_width=1e-3,
+        min_bin_height=1e-3,
+        min_derivative=1e-3, ):
     if tails is None:
         spline_fn = rational_quadratic_spline
         spline_kwargs = {}
@@ -74,9 +75,10 @@ def unconstrained_rational_quadratic_spline(
         inverse=False,
         tails="linear",
         tail_bound=1.0,
-        min_bin_width=DEFAULT_MIN_BIN_WIDTH,
-        min_bin_height=DEFAULT_MIN_BIN_HEIGHT,
-        min_derivative=DEFAULT_MIN_DERIVATIVE, ):
+        # for dygraph-to-static
+        min_bin_width=1e-3,
+        min_bin_height=1e-3,
+        min_derivative=1e-3, ):
     inside_interval_mask = (inputs >= -tail_bound) & (inputs <= tail_bound)
     outside_interval_mask = ~inside_interval_mask
 
@@ -89,8 +91,12 @@ def unconstrained_rational_quadratic_spline(
         constant = np.log(np.exp(1 - min_derivative) - 1)
         unnormalized_derivatives[..., 0] = constant
         unnormalized_derivatives[..., -1] = constant
-
-        outputs[outside_interval_mask] = inputs[outside_interval_mask]
+        # import pdb
+        # pdb.set_trace()
+        # print("inputs:",inputs)
+        # print("outside_interval_mask:",outside_interval_mask)
+        a = inputs[outside_interval_mask]
+        outputs[outside_interval_mask] = a
         logabsdet[outside_interval_mask] = 0
     else:
         raise RuntimeError("{} tails are not implemented.".format(tails))
@@ -130,9 +136,10 @@ def rational_quadratic_spline(
         right=1.0,
         bottom=0.0,
         top=1.0,
-        min_bin_width=DEFAULT_MIN_BIN_WIDTH,
-        min_bin_height=DEFAULT_MIN_BIN_HEIGHT,
-        min_derivative=DEFAULT_MIN_DERIVATIVE, ):
+        # for dygraph-to-static
+        min_bin_width=1e-3,
+        min_bin_height=1e-3,
+        min_derivative=1e-3, ):
     if paddle.min(inputs) < left or paddle.max(inputs) > right:
         raise ValueError("Input to a transform is not within its domain")
 

--- a/paddlespeech/t2s/models/vits/transform.py
+++ b/paddlespeech/t2s/models/vits/transform.py
@@ -81,9 +81,9 @@ def unconstrained_rational_quadratic_spline(
         min_derivative=1e-3, ):
     inside_interval_mask = (inputs >= -tail_bound) & (inputs <= tail_bound)
     outside_interval_mask = ~inside_interval_mask
-
-    # outputs = paddle.zeros(paddle.shape(inputs))
-    # logabsdet = paddle.zeros(paddle.shape(inputs))
+    # for dygraph to static
+    # 这里用 paddle.shape(x) 然后调用 zeros 会得到一个全 -1 shape 的 var
+    # 如果用 x.shape 的话可以保留确定的维度
     outputs = paddle.zeros(inputs.shape)
     logabsdet = paddle.zeros(inputs.shape)
     if tails == "linear":
@@ -93,12 +93,9 @@ def unconstrained_rational_quadratic_spline(
         constant = np.log(np.exp(1 - min_derivative) - 1)
         unnormalized_derivatives[..., 0] = constant
         unnormalized_derivatives[..., -1] = constant
-        # import pdb
-        # pdb.set_trace()
-        # print("inputs:",inputs)
-        # print("outside_interval_mask:",outside_interval_mask)
-        a = inputs[outside_interval_mask]
-        outputs[outside_interval_mask] = a
+        # for dygraph to static
+        tmp = inputs[outside_interval_mask]
+        outputs[outside_interval_mask] = tmp
         logabsdet[outside_interval_mask] = 0
     else:
         raise RuntimeError("{} tails are not implemented.".format(tails))
@@ -142,12 +139,12 @@ def rational_quadratic_spline(
         min_bin_width=1e-3,
         min_bin_height=1e-3,
         min_derivative=1e-3, ):
-
+    # for dygraph to static
     # if paddle.min(inputs) < left or paddle.max(inputs) > right:
     #     raise ValueError("Input to a transform is not within its domain")
 
     num_bins = unnormalized_widths.shape[-1]
-
+    # for dygraph to static
     # if min_bin_width * num_bins > 1.0:
     #     raise ValueError("Minimal bin width too large for the number of bins")
     # if min_bin_height * num_bins > 1.0:

--- a/paddlespeech/t2s/models/vits/transform.py
+++ b/paddlespeech/t2s/models/vits/transform.py
@@ -82,8 +82,10 @@ def unconstrained_rational_quadratic_spline(
     inside_interval_mask = (inputs >= -tail_bound) & (inputs <= tail_bound)
     outside_interval_mask = ~inside_interval_mask
 
-    outputs = paddle.zeros(paddle.shape(inputs))
-    logabsdet = paddle.zeros(paddle.shape(inputs))
+    # outputs = paddle.zeros(paddle.shape(inputs))
+    # logabsdet = paddle.zeros(paddle.shape(inputs))
+    outputs = paddle.zeros(inputs.shape)
+    logabsdet = paddle.zeros(inputs.shape)
     if tails == "linear":
         unnormalized_derivatives = F.pad(
             unnormalized_derivatives,
@@ -140,15 +142,16 @@ def rational_quadratic_spline(
         min_bin_width=1e-3,
         min_bin_height=1e-3,
         min_derivative=1e-3, ):
-    if paddle.min(inputs) < left or paddle.max(inputs) > right:
-        raise ValueError("Input to a transform is not within its domain")
+
+    # if paddle.min(inputs) < left or paddle.max(inputs) > right:
+    #     raise ValueError("Input to a transform is not within its domain")
 
     num_bins = unnormalized_widths.shape[-1]
 
-    if min_bin_width * num_bins > 1.0:
-        raise ValueError("Minimal bin width too large for the number of bins")
-    if min_bin_height * num_bins > 1.0:
-        raise ValueError("Minimal bin height too large for the number of bins")
+    # if min_bin_width * num_bins > 1.0:
+    #     raise ValueError("Minimal bin width too large for the number of bins")
+    # if min_bin_height * num_bins > 1.0:
+    #     raise ValueError("Minimal bin height too large for the number of bins")
 
     widths = F.softmax(unnormalized_widths, axis=-1)
     widths = min_bin_width + (1 - min_bin_width * num_bins) * widths

--- a/paddlespeech/t2s/models/vits/vits.py
+++ b/paddlespeech/t2s/models/vits/vits.py
@@ -532,3 +532,14 @@ class VITS(nn.Layer):
                         module.weight[module._padding_idx] = 0
 
         self.apply(_reset_parameters)
+
+class VITSInference(nn.Layer):
+    def __init__(self, model):
+        super().__init__()
+        self.acoustic_model = model
+
+    def forward(self, text, sids=None):
+        out = self.acoustic_model.inference(
+            text, sids=sids)
+        wav = out['wav']
+        return wav


### PR DESCRIPTION
```bash
git clone https://github.com/yt605155624/PaddleSpeech.git
cd PaddleSpeech
git checkout vits_tostatic
cd examples/csmsc/vits
wget https://paddlespeech.bj.bcebos.com/Parakeet/released_models/vits/vits_csmsc_ckpt_1.1.0.zip
unzip vits_csmsc_ckpt_1.1.0.zip
mkdir -p dump/train
mkdir -p exp/default/checkpoints
cp vits_csmsc_ckpt_1.1.0/phone_id_map.txt dump
cp vits_csmsc_ckpt_1.1.0/snapshot_iter_333000.pdz exp/default/checkpoints
vim run.sh 后 ckpt 改成 snapshot_iter_333000.pdz
# 执行执行如下代码，动态图推理不报错
./run.sh --stage 3 --stop-stage 3
# 解开 local/synthesize_e2e.sh 22 行和 21 行最后的 "\" 前面的注释
# 执行动转静并 load 之后进行推理，报错
./run.sh --stage 3 --stop-stage 3
```

paddle 修复 pr: https://github.com/PaddlePaddle/Paddle/pull/50837 -> 暂时有问题，待修复
没有问题的 paddle 修复 pr: https://github.com/PaddlePaddle/Paddle/pull/51046 -> 已验证可用

