### PR TITLE
fix Tensor.numpy()[0] to float(Tensor) to adapt 0D

### DIFF
--- a/examples/tess/cls0/local/train.py
+++ b/examples/tess/cls0/local/train.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
             optimizer.clear_grad()
 
             # Calculate loss
-            avg_loss += loss.numpy()[0]
+            avg_loss += float(loss)
 
             # Calculate metrics
             preds = paddle.argmax(logits, axis=1)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
other
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
other
### Describe
<!-- Describe what this PR does -->
有些Tensor正确的语义为0D Tensor，其shape为[]，当前使用了shape为[1]替代，也就是向量Tensor：

在升级为0D后，Tensor.numpy()[0] 的写法不再使用，将其改变为 float(Tensor) 的写法，兼容升级前后。