### PR TITLE
[TTS]fix input dtype of elementwise_mul op from bool to int64

### DIFF
--- a/paddlespeech/t2s/models/vits/generator.py
+++ b/paddlespeech/t2s/models/vits/generator.py
@@ -559,8 +559,9 @@ class VITSGenerator(nn.Layer):
             y_lengths = paddle.cast(
                 paddle.clip(paddle.sum(dur, [1, 2]), min=1), dtype='int64')
             y_mask = make_non_pad_mask(y_lengths).unsqueeze(1)
-            attn_mask = paddle.unsqueeze(x_mask, 2) * paddle.unsqueeze(y_mask,
-                                                                       -1)
+            tmp_a = paddle.cast(paddle.unsqueeze(x_mask, 2), dtype='int64')
+            tmp_b = paddle.cast(paddle.unsqueeze(y_mask, -1), dtype='int64')
+            attn_mask = tmp_a * tmp_b
             attn = self._generate_path(dur, attn_mask)
 
             # expand the length to match with the feature sequence


### PR DESCRIPTION
Paddle Lite elementwise_mul op 输入不支持 bool 类型
before:
<img width="1312" alt="image" src="https://user-images.githubusercontent.com/24568452/225314579-ff41fba0-7dfa-4874-8ae7-06fe46c2c616.png">


after:
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/24568452/225313745-9c0d154d-fd5e-4cda-939d-9345584f158b.png">
