### PR TITLE
[TTS]fix elementwise_floordiv's fill_constant

### DIFF
--- a/paddlespeech/t2s/modules/conformer/encoder_layer.py
+++ b/paddlespeech/t2s/modules/conformer/encoder_layer.py
@@ -113,7 +113,6 @@ class EncoderLayer(nn.Layer):
             x, pos_emb = x_input[0], x_input[1]
         else:
             x, pos_emb = x_input, None
-
         skip_layer = False
         # with stochastic depth, residual connection `x + f(x)` becomes
         # `x <- x + 1 / (1 - p) * f(x)` at training time.
@@ -121,14 +120,12 @@ class EncoderLayer(nn.Layer):
         if self.training and self.stochastic_depth_rate > 0:
             skip_layer = paddle.rand(1).item() < self.stochastic_depth_rate
             stoch_layer_coeff = 1.0 / (1 - self.stochastic_depth_rate)
-
         if skip_layer:
             if cache is not None:
                 x = paddle.concat([cache, x], axis=1)
             if pos_emb is not None:
                 return (x, pos_emb), mask
             return x, mask
-
         # whether to use macaron style
         if self.feed_forward_macaron is not None:
             residual = x
@@ -138,7 +135,6 @@ class EncoderLayer(nn.Layer):
                 self.feed_forward_macaron(x))
             if not self.normalize_before:
                 x = self.norm_ff_macaron(x)
-
         # multi-headed self-attention module
         residual = x
         if self.normalize_before:

--- a/paddlespeech/t2s/modules/transformer/attention.py
+++ b/paddlespeech/t2s/modules/transformer/attention.py
@@ -192,7 +192,8 @@ class RelPositionMultiHeadedAttention(MultiHeadedAttention):
         x_padded = paddle.concat([zero_pad, x], axis=-1)
         x_padded = x_padded.reshape([b, h, t2 + 1, t1])
         # only keep the positions from 0 to time2
-        x = x_padded[:, :, 1:].reshape([b, h, t1, t2])[:, :, :, :t2 // 2 + 1]
+        new_t = paddle.cast(paddle.floor(t2 / 2) + 1, dtype='int32')
+        x = x_padded[:, :, 1:].reshape([b, h, t1, t2])[:, :, :, :new_t]
 
         if self.zero_triu:
             ones = paddle.ones((t1, t2))
@@ -221,7 +222,6 @@ class RelPositionMultiHeadedAttention(MultiHeadedAttention):
         q, k, v = self.forward_qkv(query, key, value)
         # (batch, time1, head, d_k)
         q = q.transpose([0, 2, 1, 3])
-
         n_batch_pos = paddle.shape(pos_emb)[0]
         p = self.linear_pos(pos_emb).reshape(
             [n_batch_pos, -1, self.h, self.d_k])

--- a/paddlespeech/t2s/modules/transformer/attention.py
+++ b/paddlespeech/t2s/modules/transformer/attention.py
@@ -103,7 +103,7 @@ class MultiHeadedAttention(nn.Layer):
             mask = paddle.logical_not(mask)
             # assume scores.dtype==paddle.float32, we only use "float32" here
             dtype = str(scores.dtype).split(".")[-1]
-            min_value = numpy.finfo(dtype).min
+            min_value = float(numpy.finfo(dtype).min)
             scores = masked_fill(scores, mask, min_value)
             # (batch, head, time1, time2)
             self.attn = softmax(scores)
@@ -194,11 +194,9 @@ class RelPositionMultiHeadedAttention(MultiHeadedAttention):
         # only keep the positions from 0 to time2
         new_t = paddle.cast(paddle.floor(t2 / 2) + 1, dtype='int32')
         x = x_padded[:, :, 1:].reshape([b, h, t1, t2])[:, :, :, :new_t]
-
         if self.zero_triu:
             ones = paddle.ones((t1, t2))
             x = x * paddle.tril(ones, t2 - t1)[None, None, :, :]
-
         return x
 
     def forward(self, query, key, value, pos_emb, mask):

--- a/paddlespeech/t2s/modules/transformer/embedding.py
+++ b/paddlespeech/t2s/modules/transformer/embedding.py
@@ -198,7 +198,8 @@ class RelPositionalEncoding(nn.Layer):
         x = x * self.xscale
         T = paddle.shape(x)[1]
         pe_size = paddle.shape(self.pe)
-        pos_emb = self.pe[:, pe_size[1] // 2 - T + 1:pe_size[1] // 2 + T, ]
+        tmp = paddle.cast(paddle.floor(pe_size[1] / 2), dtype='int32')
+        pos_emb = self.pe[:, tmp - T + 1:tmp + T, ]
         return self.dropout(x), self.dropout(pos_emb)
 
 

--- a/paddlespeech/t2s/modules/transformer/multi_layer_conv.py
+++ b/paddlespeech/t2s/modules/transformer/multi_layer_conv.py
@@ -69,8 +69,8 @@ class MultiLayeredConv1d(nn.Layer):
             Tensor: Batch of output tensors (B, T, in_chans).
         """
         x = self.relu(self.w_1(x.transpose([0, 2, 1]))).transpose([0, 2, 1])
-        return self.w_2(self.dropout(x).transpose([0, 2, 1])).transpose(
-            [0, 2, 1])
+        out = self.w_2(self.dropout(x).transpose([0, 2, 1])).transpose([0, 2, 1])
+        return out
 
 
 class Conv1dLinear(nn.Layer):


### PR DESCRIPTION
paddle 框架的修改，导致有些位置的 fill_constant 算子之前有 shape 值但是现在没了，而没有 shape 的话 lite 推理会报错
之前的静态图
![37691fc999740b43188f0c4e6d658fc2](https://user-images.githubusercontent.com/24568452/226857274-e93045cd-3070-4b0c-bd4e-1b91515d5322.png)
paddle develop 新导出的静态图
<img width="985" alt="deb8d1328e04c113260e0c210e414389" src="https://user-images.githubusercontent.com/24568452/226857300-1711bf54-6adc-4d2a-a5ae-79d4a73f20f8.png">

移除了 elementwise_floor_div 算子，但之后发现别的位置也有问题（这个位置甚至在 fastspeech2 里面也有），最终的解决办法是 lite 同学对 fill_constant 算子做了 0D Tensor 的支持

目前在 lite 同学给的 库上测试，VITS 模型可以成功跑 lite 了
<img width="326" alt="e89cdd273c87f99184948743317bc1e8" src="https://user-images.githubusercontent.com/24568452/226853893-4a9881c5-d8e4-4b93-9c58-68b44a503b89.png">

**TODO:** 待 fill_constant 加上对 0D Tensor 的处理的 pr 合入之后再测下 fastspeech2 的 lite 推理是否可以跑通（现在因为 fill_constant 0D Tensor 的原因，用最新的 develop paddle 导出的 fastspeech2 静态模型没有办法跑通 lite。。）