### PR TITLE
[TTS]Fix VITS lite infer

### DIFF
--- a/examples/csmsc/vits/local/lite_predict.sh
+++ b/examples/csmsc/vits/local/lite_predict.sh
@@ -7,7 +7,7 @@ stage=0
 stop_stage=0
 
 if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
-    python3 ${BIN_DIR}/../lite_predict.py \
+    python3 ${BIN_DIR}/lite_predict.py \
         --inference_dir=${train_output_path}/pdlite \
         --am=vits_csmsc \
         --text=${BIN_DIR}/../sentences.txt \

--- a/examples/csmsc/vits/run.sh
+++ b/examples/csmsc/vits/run.sh
@@ -9,7 +9,7 @@ stop_stage=100
 
 conf_path=conf/default.yaml
 train_output_path=exp/default
-ckpt_name=snapshot_iter_333000.pdz
+ckpt_name=snapshot_iter_153.pdz
 add_blank=true
 
 # with the following command, you can choose the stage range you want to run
@@ -59,7 +59,8 @@ fi
 if [ ${stage} -le 7 ] && [ ${stop_stage} -ge 7 ]; then
     # NOTE by yuantian 2022.11.21: please compile develop version of Paddle-Lite to export and run TTS models,
     #                   cause TTS models are supported by https://github.com/PaddlePaddle/Paddle-Lite/pull/10128
-    ./local/export2lite.sh ${train_output_path} inference pdlite vits_csmsc x86
+    # vits can only run in arm
+    ./local/export2lite.sh ${train_output_path} inference pdlite vits_csmsc arm
 fi
 
 if [ ${stage} -le 8 ] && [ ${stop_stage} -ge 8 ]; then

--- a/examples/csmsc/vits/run.sh
+++ b/examples/csmsc/vits/run.sh
@@ -9,7 +9,7 @@ stop_stage=100
 
 conf_path=conf/default.yaml
 train_output_path=exp/default
-ckpt_name=snapshot_iter_153.pdz
+ckpt_name=snapshot_iter_333000.pdz
 add_blank=true
 
 # with the following command, you can choose the stage range you want to run
@@ -54,16 +54,15 @@ fi
 #     ./local/ort_predict.sh ${train_output_path}
 # fi
 
-# # not ready yet for operator missing in Paddle-Lite
-# # must run after stage 3 (which stage generated static models)
-# if [ ${stage} -le 7 ] && [ ${stop_stage} -ge 7 ]; then
-#     # NOTE by yuantian 2022.11.21: please compile develop version of Paddle-Lite to export and run TTS models,
-#     #                   cause TTS models are supported by https://github.com/PaddlePaddle/Paddle-Lite/pull/9587 
-#     #                   and https://github.com/PaddlePaddle/Paddle-Lite/pull/9706
-#     ./local/export2lite.sh ${train_output_path} inference pdlite vits_csmsc x86
-# fi
+# not ready yet for operator missing in Paddle-Lite
+# must run after stage 3 (which stage generated static models)
+if [ ${stage} -le 7 ] && [ ${stop_stage} -ge 7 ]; then
+    # NOTE by yuantian 2022.11.21: please compile develop version of Paddle-Lite to export and run TTS models,
+    #                   cause TTS models are supported by https://github.com/PaddlePaddle/Paddle-Lite/pull/10128
+    ./local/export2lite.sh ${train_output_path} inference pdlite vits_csmsc x86
+fi
 
-# if [ ${stage} -le 8 ] && [ ${stop_stage} -ge 8 ]; then
-#     CUDA_VISIBLE_DEVICES=${gpus} ./local/lite_predict.sh ${train_output_path} || exit -1
-# fi
+if [ ${stage} -le 8 ] && [ ${stop_stage} -ge 8 ]; then
+    CUDA_VISIBLE_DEVICES=${gpus} ./local/lite_predict.sh ${train_output_path} || exit -1
+fi
 

--- a/paddlespeech/t2s/exps/vits/lite_predict.py
+++ b/paddlespeech/t2s/exps/vits/lite_predict.py
@@ -21,6 +21,7 @@ from paddlespeech.t2s.exps.lite_syn_utils import get_lite_am_output
 from paddlespeech.t2s.exps.lite_syn_utils import get_lite_predictor
 from paddlespeech.t2s.exps.syn_utils import get_frontend
 from paddlespeech.t2s.exps.syn_utils import get_sentences
+from paddlespeech.t2s.utils import str2bool
 
 
 def parse_args():
@@ -75,12 +76,12 @@ def main():
     # frontend
     frontend = get_frontend(
         lang=args.lang,
-        phones_dict=args.phones_dict,
-        tones_dict=args.tones_dict)
+        phones_dict=args.phones_dict)
 
     # am_predictor
+    # vits can only run in arm
     am_predictor = get_lite_predictor(
-        model_dir=args.inference_dir, model_file=args.am + "_x86.nb")
+        model_dir=args.inference_dir, model_file=args.am + "_arm.nb")
     # model: {model_name}_{dataset}
     am_dataset = args.am[args.am.rindex('_') + 1:]
 


### PR DESCRIPTION
复现步骤
```bash
# 编译 Paddle-Lite https://github.com/PaddlePaddle/Paddle-Lite/pull/10128
git clone https://github.com/yt605155624/PaddleSpeech.git
cd PaddleSpeech
git checkout vits_liteinfer
# 安装
pip install .
cd examples/csmsc/vits
wget https://paddlespeech.bj.bcebos.com/Parakeet/released_models/vits/vits_csmsc_ckpt_1.1.0.zip
unzip vits_csmsc_ckpt_1.1.0.zip
mkdir -p dump/train
mkdir -p exp/default/checkpoints
cp vits_csmsc_ckpt_1.1.0/phone_id_map.txt dump
cp vits_csmsc_ckpt_1.1.0/snapshot_iter_333000.pdz exp/default/checkpoints
vim run.sh 后 ckpt 改成 snapshot_iter_333000.pdz
# 解开 local/synthesize_e2e.sh 22 行和 21 行最后的 "\" 前面的注释
# 执行动转静并 load 之后进行推理, 生成静态图模型
./run.sh --stage 3 --stop-stage 3
# 静态图推理，默认使用 gpu，如果环境不支持可以修改 https://github.com/yt605155624/PaddleSpeech/blob/793effa12232debc5a47fea8d812244df20a9c89/paddlespeech/t2s/exps/vits/inference.py#L84
./run.sh --stage 4 --stop-stage 4
# 合成的音频在 exp/default/pd_infer_out
# 使用 opt 转 lite 模型（arm）
./run.sh --stage 7 --stop-stage 7
# lite 推理
./run.sh --stage 8 --stop-stage 8
# 合成的音频在 exp/default/lite_infer_out 是静音
```