### PR TITLE
[BUG] Fix progress bar unit.

### DIFF
--- a/paddlespeech/cli/download.py
+++ b/paddlespeech/cli/download.py
@@ -133,8 +133,8 @@ def _get_download(url, fullname):
     total_size = req.headers.get('content-length')
     with open(tmp_fullname, 'wb') as f:
         if total_size:
-            with tqdm(total=(int(total_size))) as pbar:
-                for chunk in req.iter_content(chunk_size=1024, unit='B', unit_scale=True):
+            with tqdm(total=(int(total_size)), unit='B', unit_scale=True) as pbar:
+                for chunk in req.iter_content(chunk_size=1024):
                     f.write(chunk)
                     pbar.update(len(chunk))
         else:

--- a/paddlespeech/cli/download.py
+++ b/paddlespeech/cli/download.py
@@ -133,10 +133,10 @@ def _get_download(url, fullname):
     total_size = req.headers.get('content-length')
     with open(tmp_fullname, 'wb') as f:
         if total_size:
-            with tqdm(total=(int(total_size) + 1023) // 1024) as pbar:
-                for chunk in req.iter_content(chunk_size=1024):
+            with tqdm(total=(int(total_size))) as pbar:
+                for chunk in req.iter_content(chunk_size=1024, unit='B', unit_scale=True):
                     f.write(chunk)
-                    pbar.update(1)
+                    pbar.update(len(chunk))
         else:
             for chunk in req.iter_content(chunk_size=1024):
                 if chunk:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Change the unit of progress bar while downloading pretrained model.
From meanless it(iteration) to B(Byte).