### PR TITLE
[Bug fixes]: 修复启动时numpy报错

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ base = [
     "webrtcvad",
     "yacs~=0.1.8",
     "zhon",
+    "numpy==1.23.5",
 ]
 
 server = ["pattern_singleton", "websockets"]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
现有的`setup.py`中，没有指定numpy版本，导致在安装环境时，会去安装最新的numpy版本，在最新的numpy版本中，已经没有`np.complex`了（在1.24.0被废弃），导致启动报错（典型场景，控制台），因此增加了numpy版本限定

已经有相关issue：https://github.com/PaddlePaddle/PaddleSpeech/issues/3235

doc: https://numpy.org/devdocs/release/1.24.0-notes.html
