### PR TITLE
[t2s] fix error in tts and st for 0-D tensor

### DIFF
--- a/paddlespeech/cli/st/infer.py
+++ b/paddlespeech/cli/st/infer.py
@@ -252,7 +252,7 @@ class STExecutor(BaseExecutor):
             norm_feat = dict(kaldiio.load_ark(process.stdout))[utt_name]
             self._inputs["audio"] = paddle.to_tensor(norm_feat).unsqueeze(0)
             self._inputs["audio_len"] = paddle.to_tensor(
-                self._inputs["audio"].shape[1], dtype="int64")
+                self._inputs["audio"].shape[1:2], dtype="int64")
         else:
             raise ValueError("Wrong model type.")
 

--- a/paddlespeech/cli/tts/infer.py
+++ b/paddlespeech/cli/tts/infer.py
@@ -491,7 +491,7 @@ class TTSExecutor(BaseExecutor):
                 # multi speaker
                 if am_dataset in {'aishell3', 'vctk', 'mix', 'canton'}:
                     mel = self.am_inference(
-                        part_phone_ids, spk_id=paddle.to_tensor(spk_id))
+                        part_phone_ids, spk_id=paddle.to_tensor([spk_id]))
                 else:
                     mel = self.am_inference(part_phone_ids)
             self.am_time += (time.time() - am_st)

--- a/paddlespeech/t2s/models/fastspeech2/fastspeech2.py
+++ b/paddlespeech/t2s/models/fastspeech2/fastspeech2.py
@@ -783,7 +783,7 @@ class FastSpeech2(nn.Layer):
         x = paddle.cast(text, 'int64')
         d, p, e = durations, pitch, energy
         # setup batch axis
-        ilens = paddle.shape(x)[0]
+        ilens = paddle.shape(x)[0:1]
 
         xs = x.unsqueeze(0)
 

--- a/paddlespeech/t2s/modules/nets_utils.py
+++ b/paddlespeech/t2s/modules/nets_utils.py
@@ -181,7 +181,7 @@ def make_pad_mask(lengths, xs=None, length_dim=-1):
     if length_dim == 0:
         raise ValueError("length_dim cannot be 0: {}".format(length_dim))
 
-    bs = paddle.shape(lengths)[0]
+    bs = paddle.shape(lengths)
     if xs is None:
         maxlen = paddle.cast(lengths.max(), dtype=bs.dtype)
     else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix inference error in st/tts brought by API 0-D changes.
```bash
>>> PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python paddlespeech tts --am fastspeech2_aishell3 --voc pwgan_aishell3 --input '你好，欢迎使用百度飞桨深度学习框架！' --spk_id 0

grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
W0522 10:33:17.536437  8222 gpu_resources.cc:119] Please NOTE: device: 0, GPU Compute Capability: 6.1, Driver API Version: 11.0, Runtime API Version: 11.0
W0522 10:33:17.541528  8222 gpu_resources.cc:149] device: 0, cuDNN Version: 8.0.
W0522 10:33:17.541566  8222 gpu_resources.cc:175] WARNING: device: 0. The installed Paddle is compiled with CUDA 11.2, but CUDA runtime version in your machine is 11.0, which may cause serious incompatible bug. Please recompile or reinstall Paddle with compatible CUDA version.
I0522 10:33:22.421573  8222 eager_method.cc:140] Warning:: 0D Tensor cannot be used as 'Tensor.numpy()[0]' . In order to avoid this problem, 0D Tensor will be changed to 1D numpy currently, but it's not correct and will be removed in release 2.6. For Tensor contain only one element, Please modify  'Tensor.numpy()[0]' to 'float(Tensor)' as soon as possible, otherwise 'Tensor.numpy()[0]' will raise error in release 2.6.
I0522 10:33:22.425954  8222 eager_method.cc:140] Warning:: 0D Tensor cannot be used as 'Tensor.numpy()[0]' . In order to avoid this problem, 0D Tensor will be changed to 1D numpy currently, but it's not correct and will be removed in release 2.6. For Tensor contain only one element, Please modify  'Tensor.numpy()[0]' to 'float(Tensor)' as soon as possible, otherwise 'Tensor.numpy()[0]' will raise error in release 2.6.
W0522 10:33:32.974318  8222 gpu_resources.cc:275] WARNING: device: . The installed Paddle is compiled with CUDNN 8.2, but CUDNN version in your machine is 8.0, which may cause serious incompatible bug. Please recompile or reinstall Paddle with compatible CUDNN version.
/root/workspace/base/PaddleSpeech/output.wav
```

```
>>> paddlespeech st --input ./en.wav

grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
W0522 10:32:24.795339  8160 gpu_resources.cc:119] Please NOTE: device: 0, GPU Compute Capability: 6.1, Driver API Version: 11.0, Runtime API Version: 11.0
W0522 10:32:24.799633  8160 gpu_resources.cc:149] device: 0, cuDNN Version: 8.0.
W0522 10:32:24.799665  8160 gpu_resources.cc:175] WARNING: device: 0. The installed Paddle is compiled with CUDA 11.2, but CUDA runtime version in your machine is 11.0, which may cause serious incompatible bug. Please recompile or reinstall Paddle with compatible CUDA version.
W0522 10:32:33.337348  8160 gpu_resources.cc:275] WARNING: device: . The installed Paddle is compiled with CUDNN 8.2, but CUDNN version in your machine is 8.0, which may cause serious incompatible bug. Please recompile or reinstall Paddle with compatible CUDNN version.
/usr/local/lib/python3.8/dist-packages/paddle/fluid/variable_index.py:592: UserWarning: Warning: In Tensor '__getitem__', if the number of scalar elements in the index is equal to the rank of the Tensor, the output should be 0-D. In order to be consistent with the behavior of previous versions, it will be processed to 1-D. But it is not correct and will be removed in release 2.6. If 1-D is still wanted, please modify the index element from scalar to slice (e.g. 'x[i]' => 'x[i:i+1]').
  warnings.warn(
['我 在 这栋 建筑 的 古老 门上 敲门 。']
```
