### PR TITLE
Optimise an issue with the order of replacement of units, test=tts

### DIFF
--- a/paddlespeech/t2s/frontend/zh_normalization/quantifier.py
+++ b/paddlespeech/t2s/frontend/zh_normalization/quantifier.py
@@ -57,7 +57,7 @@ def replace_temperature(match) -> str:
 
 
 def replace_measure(sentence) -> str:
-    for q_notation in measure_dict:
+    for q_notation in sorted(measure_dict, key=len, reverse=True):
         if q_notation in sentence:
             sentence = sentence.replace(q_notation, measure_dict[q_notation])
     return sentence


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 

### Describe
<!-- Describe what this PR does -->
t2s里，英文单位替换为中文时，`  "m": "米",`在` "mm": "毫米",`之前，导致“mm”会被替换为“米米”而非“毫米”。因此先对较长的单位进行替换以避免较长的单位被替换为了较短的单位。