### PR TITLE
fix scipy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ base = [
     # paddleaudio align with librosa==0.8.1, which need numpy==1.23.x
     "numpy==1.23.5",
     "librosa==0.8.1",
-    "scipy>=1.4.0",
+    "scipy>=1.4.0, <=1.12.0",
     "loguru",
     "matplotlib",
     "nara_wpe",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Due to an incompatible upgrade of the third-party library Scipy, the use of TTS has been affected. 
Higher versions of Scipy require adaptation to higher versions of Python, for also support Python 3.8, its highest version has been fixed.