### PR TITLE
【TTS】fix matplotlib version for incompatible upgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ base = [
     "librosa==0.8.1",
     "scipy>=1.4.0, <=1.12.0",
     "loguru",
-    "matplotlib",
+    "matplotlib<=3.8.4",
     "nara_wpe",
     "onnxruntime>=1.11.0",
     "opencc==1.1.6",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
For incompatible upgrade of matplotlib>3.9,   `matplotlib.pyplot.get_cmap()` replace `matplotlib.cm.get_cmap()`and rise import error. For fix issue like https://github.com/PaddlePaddle/PaddleSpeech/issues/3812 , fixed  matplotlib version here.

