### PR TITLE
Fix wav2vec error in Demos/ssl

### DIFF
--- a/paddlespeech/cli/ssl/infer.py
+++ b/paddlespeech/cli/ssl/infer.py
@@ -119,6 +119,7 @@ class SSLExecutor(BaseExecutor):
             '--verbose',
             action='store_true',
             help='Increase logger verbosity of current task.')
+        self.last_call_params = None
 
     def _init_from_path(self,
                         model_type: str=None,
@@ -287,8 +288,8 @@ class SSLExecutor(BaseExecutor):
                 f"we will use the {model_type} like model to extract audio feature."
             )
             try:
-                out_feature = self.model.extract_features(audio[:, :, 0])
-                self._outputs["result"] = out_feature
+                out_feature = self.model(audio[:, :, 0])
+                self._outputs["result"] = out_feature[0]
             except Exception as e:
                 logger.exception(e)
 
@@ -452,6 +453,22 @@ class SSLExecutor(BaseExecutor):
         """
         Python API to call an executor.
         """
+
+        current_call_params = {
+            "model": model,
+            "task": task,
+            "lang": lang,
+            "sample_rate": sample_rate,
+            "config": config,
+            "ckpt_path": ckpt_path,
+            "decode_method": decode_method,
+            "force_yes": force_yes,
+            "rtf": rtf,
+            "device": device
+        }
+        if self.last_call_params is not None and self.last_call_params != current_call_params and hasattr(self, 'model'):
+            del self.model
+        self.last_call_params = current_call_params
 
         audio_file = os.path.abspath(audio_file)
         paddle.set_device(device)

--- a/paddlespeech/cli/ssl/infer.py
+++ b/paddlespeech/cli/ssl/infer.py
@@ -466,7 +466,8 @@ class SSLExecutor(BaseExecutor):
             "rtf": rtf,
             "device": device
         }
-        if self.last_call_params is not None and self.last_call_params != current_call_params and hasattr(self, 'model'):
+        if self.last_call_params is not None and self.last_call_params != current_call_params and hasattr(
+                self, 'model'):
             del self.model
         self.last_call_params = current_call_params
 

--- a/paddlespeech/cli/ssl/infer.py
+++ b/paddlespeech/cli/ssl/infer.py
@@ -287,8 +287,8 @@ class SSLExecutor(BaseExecutor):
                 f"we will use the {model_type} like model to extract audio feature."
             )
             try:
-                out_feature = self.model(audio[:, :, 0])
-                self._outputs["result"] = out_feature[0]
+                out_feature = self.model.extract_features(audio[:, :, 0])
+                self._outputs["result"] = out_feature
             except Exception as e:
                 logger.exception(e)
 

--- a/paddlespeech/s2t/models/wav2vec2/wav2vec2_ASR.py
+++ b/paddlespeech/s2t/models/wav2vec2/wav2vec2_ASR.py
@@ -84,18 +84,15 @@ class Wav2vec2ASR(nn.Layer):
     def extract_features(self, wav):
         if self.normalize_wav:
             wav = F.layer_norm(wav, wav.shape[-1])
- 
         # Extract wav2vec output
         out = self.wav2vec2(wav)[0]
         # We normalize the output if required
         if self.output_norm:
             out = F.layer_norm(out, out.shape[-1])
- 
         if self.training and hasattr(self.config, 'spec_augment'):
             feats = self.spec_augment(out)
         else:
             feats = out
- 
         return feats
 
     @paddle.no_grad()

--- a/paddlespeech/s2t/models/wav2vec2/wav2vec2_ASR.py
+++ b/paddlespeech/s2t/models/wav2vec2/wav2vec2_ASR.py
@@ -81,24 +81,6 @@ class Wav2vec2ASR(nn.Layer):
         return ctc_loss
 
     @paddle.no_grad()
-    def extract_features(self, wav):
-        if self.normalize_wav:
-            wav = F.layer_norm(wav, wav.shape[-1])
-
-        # Extract wav2vec output
-        out = self.wav2vec2(wav)[0]
-        # We normalize the output if required
-        if self.output_norm:
-            out = F.layer_norm(out, out.shape[-1])
-
-        if self.training and hasattr(self.config, 'spec_augment'):
-            feats = self.spec_augment(out)
-        else:
-            feats = out
-
-        return feats
-
-    @paddle.no_grad()
     def decode(self,
                feats: paddle.Tensor,
                text_feature: Dict[str, int],

--- a/paddlespeech/s2t/models/wav2vec2/wav2vec2_ASR.py
+++ b/paddlespeech/s2t/models/wav2vec2/wav2vec2_ASR.py
@@ -81,6 +81,24 @@ class Wav2vec2ASR(nn.Layer):
         return ctc_loss
 
     @paddle.no_grad()
+    def extract_features(self, wav):
+        if self.normalize_wav:
+            wav = F.layer_norm(wav, wav.shape[-1])
+ 
+        # Extract wav2vec output
+        out = self.wav2vec2(wav)[0]
+        # We normalize the output if required
+        if self.output_norm:
+            out = F.layer_norm(out, out.shape[-1])
+ 
+        if self.training and hasattr(self.config, 'spec_augment'):
+            feats = self.spec_augment(out)
+        else:
+            feats = out
+ 
+        return feats
+
+    @paddle.no_grad()
     def decode(self,
                feats: paddle.Tensor,
                text_feature: Dict[str, int],

--- a/paddlespeech/s2t/models/wav2vec2/wav2vec2_ASR.py
+++ b/paddlespeech/s2t/models/wav2vec2/wav2vec2_ASR.py
@@ -84,15 +84,18 @@ class Wav2vec2ASR(nn.Layer):
     def extract_features(self, wav):
         if self.normalize_wav:
             wav = F.layer_norm(wav, wav.shape[-1])
+
         # Extract wav2vec output
         out = self.wav2vec2(wav)[0]
         # We normalize the output if required
         if self.output_norm:
             out = F.layer_norm(out, out.shape[-1])
+
         if self.training and hasattr(self.config, 'spec_augment'):
             feats = self.spec_augment(out)
         else:
             feats = out
+
         return feats
 
     @paddle.no_grad()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs  
### Describe
#### 问题描述
调用SSLExecutor执行 wav2asr命令时，会加载asr模型，此时forward函数需要4个输入参数。调用SSLExecutor执行 wav2vec命令时，加载Base模型，forward只需要一个输入参数。

如果Python API先调用wav2asr，再调用wav2vec，SSLExecutor会因为model已存在，从而不会切换模型。提取特征时，wav2vec的代码会调用asr模型的forward函数，进而引发报错。

#### 修改方式
检测SSLExecutor输入是否发生变化，如果输入的参数配置不同，删除model，从而重新加载对应的模型。