### PR TITLE
【Hackathon 7th】add implemention of strtobool

### DIFF
--- a/dataset/librispeech/librispeech.py
+++ b/dataset/librispeech/librispeech.py
@@ -30,6 +30,7 @@ import soundfile
 
 from paddlespeech.dataset.download import download
 from paddlespeech.dataset.download import unpack
+from paddlespeech.utils.argparse import strtobool
 
 URL_ROOT = "http://openslr.elda.org/resources/12"
 #URL_ROOT = "https://openslr.magicdatatech.com/resources/12"
@@ -63,7 +64,7 @@ parser.add_argument(
 parser.add_argument(
     "--full_download",
     default="True",
-    type=distutils.util.strtobool,
+    type=strtobool,
     help="Download all datasets for Librispeech."
     " If False, only download a minimal requirement (test-clean, dev-clean"
     " train-clean-100). (default: %(default)s)")

--- a/dataset/librispeech/librispeech.py
+++ b/dataset/librispeech/librispeech.py
@@ -32,6 +32,7 @@ from paddlespeech.dataset.download import download
 from paddlespeech.dataset.download import unpack
 from paddlespeech.utils.argparse import strtobool
 
+
 URL_ROOT = "http://openslr.elda.org/resources/12"
 #URL_ROOT = "https://openslr.magicdatatech.com/resources/12"
 URL_TEST_CLEAN = URL_ROOT + "/test-clean.tar.gz"

--- a/dataset/librispeech/librispeech.py
+++ b/dataset/librispeech/librispeech.py
@@ -32,7 +32,6 @@ from paddlespeech.dataset.download import download
 from paddlespeech.dataset.download import unpack
 from paddlespeech.utils.argparse import strtobool
 
-
 URL_ROOT = "http://openslr.elda.org/resources/12"
 #URL_ROOT = "https://openslr.magicdatatech.com/resources/12"
 URL_TEST_CLEAN = URL_ROOT + "/test-clean.tar.gz"

--- a/examples/ami/sd0/local/ami_prepare.py
+++ b/examples/ami/sd0/local/ami_prepare.py
@@ -28,7 +28,8 @@ import xml.etree.ElementTree as et
 from ami_splits import get_AMI_split
 from dataio import load_pkl
 from dataio import save_pkl
-from distutils.util import strtobool
+
+from paddlespeech.utils.argparse import strtobool
 
 logger = logging.getLogger(__name__)
 SAMPLERATE = 16000

--- a/paddlespeech/s2t/decoders/recog_bin.py
+++ b/paddlespeech/s2t/decoders/recog_bin.py
@@ -21,7 +21,8 @@ import sys
 
 import configargparse
 import numpy as np
-from distutils.util import strtobool
+
+from paddlespeech.utils.argparse import strtobool
 
 
 def get_parser():

--- a/paddlespeech/s2t/exps/whisper/test_wav.py
+++ b/paddlespeech/s2t/exps/whisper/test_wav.py
@@ -27,6 +27,7 @@ from paddlespeech.s2t.models.whisper import transcribe
 from paddlespeech.s2t.models.whisper import Whisper
 from paddlespeech.s2t.training.cli import default_argument_parser
 from paddlespeech.s2t.utils.log import Log
+from paddlespeech.utils.argparse import strtobool
 
 logger = Log(__name__).getlog()
 
@@ -103,10 +104,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--audio_file", type=str, help="path of the input audio file")
     parser.add_argument(
-        "--debug",
-        type=distutils.util.strtobool,
-        default=False,
-        help="for debug.")
+        "--debug", type=strtobool, default=False, help="for debug.")
     args = parser.parse_args()
 
     config = CfgNode(new_allowed=True)

--- a/paddlespeech/s2t/training/cli.py
+++ b/paddlespeech/s2t/training/cli.py
@@ -16,6 +16,8 @@ import argparse
 import distutils
 from yacs.config import CfgNode
 
+from paddlespeech.utils.argparse import strtobool
+
 
 class ExtendAction(argparse.Action):
     """
@@ -73,7 +75,7 @@ def default_argument_parser(parser=None):
         '--conf', type=open, action=LoadFromFile, help="config file.")
     parser.add_argument(
         "--debug",
-        type=distutils.util.strtobool,
+        type=strtobool,
         default=False,
         help="logging with debug mode.")
     parser.add_argument(

--- a/paddlespeech/s2t/utils/cli_utils.py
+++ b/paddlespeech/s2t/utils/cli_utils.py
@@ -16,11 +16,12 @@ import sys
 from collections.abc import Sequence
 
 import numpy
-from distutils.util import strtobool as dist_strtobool
+
+from paddlespeech.utils.argparse import strtobool as dist_strtobool
 
 
 def strtobool(x):
-    # distutils.util.strtobool returns integer, but it's confusing,
+    # paddlespeech.utils.argparse.strtobool returns integer, but it's confusing,
     return bool(dist_strtobool(x))
 
 

--- a/paddlespeech/utils/argparse.py
+++ b/paddlespeech/utils/argparse.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 import hashlib
 import os
 import sys
@@ -18,7 +19,9 @@ from typing import Text
 
 import distutils
 
-__all__ = ["print_arguments", "add_arguments", "get_commandline_args"]
+__all__ = [
+    "print_arguments", "add_arguments", "get_commandline_args", "strtobool"
+]
 
 
 def get_commandline_args():
@@ -80,6 +83,27 @@ def print_arguments(args, info=None):
     print("-----------------------------------------------------------")
 
 
+def strtobool(value):
+    """Convert a string value to an integer boolean (1 for True, 0 for False).
+
+    The function recognizes the following strings as True (case insensitive):
+    - "yes"
+    - "true"
+    - "1"
+
+    All other values are considered False.
+
+    NOTE: After Python 3.10, the distutils module, particularly distutils.util, has been partially deprecated. To maintain compatibility with existing code, the strtobool function implemented here.
+    """
+    if isinstance(value, bool):
+        return int(value)
+    value = value.strip().lower()
+    if value in ('yes', 'true', '1'):
+        return 1
+    else:
+        return 0
+
+
 def add_arguments(argname, type, default, help, argparser, **kwargs):
     """Add argparse's argument.
 
@@ -91,7 +115,7 @@ def add_arguments(argname, type, default, help, argparser, **kwargs):
         add_argument("name", str, "Jonh", "User name.", parser)
         args = parser.parse_args()
     """
-    type = distutils.util.strtobool if type == bool else type
+    type = strtobool if type == bool else type
     argparser.add_argument(
         "--" + argname,
         default=default,

--- a/paddlespeech/utils/argparse.py
+++ b/paddlespeech/utils/argparse.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import argparse
 import hashlib
 import os
 import sys

--- a/paddlespeech/vector/cluster/diarization.py
+++ b/paddlespeech/vector/cluster/diarization.py
@@ -24,7 +24,6 @@ import warnings
 import numpy as np
 import scipy
 import sklearn
-from distutils.util import strtobool
 from scipy import linalg
 from scipy import sparse
 from scipy.sparse.csgraph import connected_components
@@ -33,6 +32,8 @@ from scipy.sparse.linalg import eigsh
 from sklearn.cluster import SpectralClustering
 from sklearn.cluster._kmeans import k_means
 from sklearn.neighbors import kneighbors_graph
+
+from paddlespeech.utils.argparse import strtobool
 
 
 def _graph_connected_component(graph, node_id):

--- a/utils/DER.py
+++ b/utils/DER.py
@@ -28,7 +28,8 @@ import re
 import subprocess
 
 import numpy as np
-from distutils.util import strtobool
+
+from paddlespeech.utils.argparse import strtobool
 
 FILE_IDS = re.compile(r"(?<=Speaker Diarization for).+(?=\*\*\*)")
 SCORED_SPEAKER_TIME = re.compile(r"(?<=SCORED SPEAKER TIME =)[\d.]+")

--- a/utils/addjson.py
+++ b/utils/addjson.py
@@ -11,8 +11,9 @@ import json
 import logging
 import sys
 
-from distutils.util import strtobool
 from espnet.utils.cli_utils import get_commandline_args
+
+from paddlespeech.utils.argparse import strtobool
 
 is_python2 = sys.version_info[0] == 2
 

--- a/utils/apply-cmvn.py
+++ b/utils/apply-cmvn.py
@@ -4,13 +4,13 @@ import logging
 
 import kaldiio
 import numpy
-from distutils.util import strtobool
 
 from paddlespeech.audio.transform.cmvn import CMVN
 from paddlespeech.s2t.utils.cli_readers import file_reader_helper
 from paddlespeech.s2t.utils.cli_utils import get_commandline_args
 from paddlespeech.s2t.utils.cli_utils import is_scipy_wav_style
 from paddlespeech.s2t.utils.cli_writers import file_writer_helper
+from paddlespeech.utils.argparse import strtobool
 
 
 def get_parser():

--- a/utils/copy-feats.py
+++ b/utils/copy-feats.py
@@ -2,13 +2,12 @@
 import argparse
 import logging
 
-from distutils.util import strtobool
-
 from paddlespeech.audio.transform.transformation import Transformation
 from paddlespeech.s2t.utils.cli_readers import file_reader_helper
 from paddlespeech.s2t.utils.cli_utils import get_commandline_args
 from paddlespeech.s2t.utils.cli_utils import is_scipy_wav_style
 from paddlespeech.s2t.utils.cli_writers import file_writer_helper
+from paddlespeech.utils.argparse import strtobool
 
 
 def get_parser():

--- a/utils/merge_scp2json.py
+++ b/utils/merge_scp2json.py
@@ -7,9 +7,8 @@ import logging
 import sys
 from io import open
 
-from distutils.util import strtobool
-
 from paddlespeech.s2t.utils.cli_utils import get_commandline_args
+from paddlespeech.utils.argparse import strtobool
 
 PY2 = sys.version_info[0] == 2
 sys.stdin = codecs.getreader("utf-8")(sys.stdin if PY2 else sys.stdin.buffer)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
从Python3.10后已经弃用 distutils.util.strtobool ，会导致部分脚本无法跑通，为了提高兼容性，手动实现strtobool 函数。