### PR TITLE
fix type promotion TypeError in tensor_utils.py

### DIFF
--- a/paddlespeech/audio/utils/tensor_utils.py
+++ b/paddlespeech/audio/utils/tensor_utils.py
@@ -177,8 +177,9 @@ def th_accuracy(pad_outputs: paddle.Tensor,
     Returns:
         float: Accuracy value (0.0 - 1.0).
     """
-    pad_pred = pad_outputs.view(pad_targets.shape[0], pad_targets.shape[1],
-                                pad_outputs.shape[1]).argmax(2)
+    pad_pred = pad_outputs.reshape(
+        [pad_targets.shape[0], pad_targets.shape[1],
+         pad_outputs.shape[1]]).argmax(2)
     mask = pad_targets != ignore_label
     #TODO(Hui Zhang): sum not support bool type
     # numerator = paddle.sum(
@@ -248,7 +249,7 @@ def st_reverse_pad_list(ys_pad: paddle.Tensor,
     #   >>> tensor([[ 2,  1,  0],
     #   >>>         [ 2,  1,  0],
     #   >>>         [ 0, -1, -2]])
-    index = index * seq_mask
+    index = index * seq_mask.astype(index.dtype)
 
     #   >>> index
     #   >>> tensor([[2, 1, 0],


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 

### Describe
<!-- Describe what this PR does -->
This pull request includes changes to the `paddlespeech/audio/utils/tensor_utils.py` file to improve tensor manipulation functions. The key changes involve modifying tensor reshaping and type casting to ensure compatibility and correctness.

Improvements to tensor manipulation:

* [`paddlespeech/audio/utils/tensor_utils.py`](diffhunk://#diff-824137d02e470ca924709c3be9125fa03c54f002a1c234d0605feb1a7a2e1844L180-R182): Changed `view` to `reshape` for tensor reshaping in the `th_accuracy` function to improve clarity and compatibility.
* [`paddlespeech/audio/utils/tensor_utils.py`](diffhunk://#diff-824137d02e470ca924709c3be9125fa03c54f002a1c234d0605feb1a7a2e1844L251-R252): Added type casting to `index` in the `st_reverse_pad_list` function to ensure the correct data type is used.