### PR TITLE
[Hackathon 7th] 修复 opencopop的svs1中安装依赖包问题

### DIFF
--- a/examples/opencpop/svs1/README.md
+++ b/examples/opencpop/svs1/README.md
@@ -7,9 +7,12 @@ This example contains code used to train a [DiffSinger](https://arxiv.org/abs/21
 Download Opencpop from it's [Official Website](https://wenet.org.cn/opencpop/download/) and extract it to `~/datasets`. Then the dataset is in the directory `~/datasets/Opencpop`.
 
 ### pip install
+<!-- Comment: Cause ppdiffusers will install newest huggingface_hub, but cached_download function has been removed, So need to install the specified version.>
+<!-- TODO: If the corresponding dependency library is OK, it needs to be deleted.-->
 ```shell
 pip install huggingface_hub==0.25.2
 ```
+
 
 
 ## Get Started

--- a/examples/opencpop/svs1/README.md
+++ b/examples/opencpop/svs1/README.md
@@ -6,6 +6,12 @@ This example contains code used to train a [DiffSinger](https://arxiv.org/abs/21
 ### Download and Extract
 Download Opencpop from it's [Official Website](https://wenet.org.cn/opencpop/download/) and extract it to `~/datasets`. Then the dataset is in the directory `~/datasets/Opencpop`.
 
+### pip install
+```shell
+pip install huggingface_hub==0.25.2
+```
+
+
 ## Get Started
 Assume the path to the dataset is `~/datasets/Opencpop`.
 Run the command below to

--- a/examples/opencpop/svs1/README_cn.md
+++ b/examples/opencpop/svs1/README_cn.md
@@ -7,6 +7,11 @@
 ### 下载并解压
 从 [官方网站](https://wenet.org.cn/opencpop/download/) 下载数据集
 
+### pip 安装
+```shell
+pip install huggingface_hub==0.25.2
+```
+
 ## 开始
 假设数据集的路径是 `~/datasets/Opencpop`.
 运行下面的命令会进行如下操作：

--- a/examples/opencpop/svs1/README_cn.md
+++ b/examples/opencpop/svs1/README_cn.md
@@ -8,6 +8,8 @@
 从 [官方网站](https://wenet.org.cn/opencpop/download/) 下载数据集
 
 ### pip 安装
+<!-- 注释: 因为ppdiffusion会安装最新的huggingface_hub，但cached_download功能已被删除，所以需要安装指定的版本。>
+<!-- 待完成: 如果相应的依赖库正常，则将其删除。-->
 ```shell
 pip install huggingface_hub==0.25.2
 ```


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
因为ppdiffusers会自动装最新的huggingface_hub，但是其中函数cached_downloaded已经被删除
- https://github.com/huggingface/huggingface_hub/pull/2579
所以需要单独安装旧版本，暂定0.25.2。