### PR TITLE
[Hackathon 7th] 修复 `tal_cs` 测试中 0D tensor to 1D

### DIFF
--- a/paddlespeech/s2t/exps/deepspeech2/bin/test_wav.py
+++ b/paddlespeech/s2t/exps/deepspeech2/bin/test_wav.py
@@ -75,7 +75,7 @@ class DeepSpeech2Tester_hub():
         feat = self.preprocessing(audio, **self.preprocess_args)
         logger.info(f"feat shape: {feat.shape}")
 
-        audio_len = paddle.to_tensor(feat.shape[0])
+        audio_len = paddle.to_tensor(feat.shape[0]).unsqueeze(0)
         audio = paddle.to_tensor(feat, dtype='float32').unsqueeze(axis=0)
 
         result_transcripts = self.compute_result_transcripts(

--- a/paddlespeech/s2t/exps/u2/bin/quant.py
+++ b/paddlespeech/s2t/exps/u2/bin/quant.py
@@ -75,7 +75,7 @@ class U2Infer():
                     feat = self.preprocessing(audio, **self.preprocess_args)
                     logger.info(f"feat shape: {feat.shape}")
 
-                    ilen = paddle.to_tensor(feat.shape[0])
+                    ilen = paddle.to_tensor(feat.shape[0]).unsqueeze(0)
                     xs = paddle.to_tensor(feat, dtype='float32').unsqueeze(0)
                     decode_config = self.config.decode
                     logger.info(f"decode cfg: {decode_config}")

--- a/paddlespeech/s2t/exps/u2/bin/test_wav.py
+++ b/paddlespeech/s2t/exps/u2/bin/test_wav.py
@@ -78,7 +78,7 @@ class U2Infer():
             if self.args.debug:
                 np.savetxt("feat.transform.txt", feat)
 
-            ilen = paddle.to_tensor(feat.shape[0])
+            ilen = paddle.to_tensor(feat.shape[0]).unsqueeze(0)
             xs = paddle.to_tensor(feat, dtype='float32').unsqueeze(0)
             decode_config = self.config.decode
             logger.info(f"decode cfg: {decode_config}")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复 `tal_cs` 测试中 0D tensor to 1D

原代码中

``` python
ilen = paddle.to_tensor(feat.shape[0])
```

在 paddle 3.0 中是个 0D 的 tensor，而这里实际需要的是 1D 的，否则报错

``` shell
> CUDA_VISIBLE_DEVICES= ./local/test_wav.sh conf/conformer.yaml conf/tuning/decode.yaml exp/conformer/checkpoints/avg_10 data/demo_01_03.wav

 File "/home/aistudio/PaddleSpeech/paddlespeech/s2t/exps/u2/bin/test_wav.py", line 130, in <module>
    main(config, args)
  File "/home/aistudio/PaddleSpeech/paddlespeech/s2t/exps/u2/bin/test_wav.py", line 122, in main
    U2Infer(config, args).run()
  File "/home/aistudio/PaddleSpeech/paddlespeech/s2t/exps/u2/bin/test_wav.py", line 86, in run
    result_transcripts = self.model.decode(
  File "/usr/local/lib/python3.8/dist-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/base/dygraph/base.py", line 397, in _decorate_function
    return func(*args, **kwargs)
  File "/home/aistudio/PaddleSpeech/paddlespeech/s2t/models/u2/u2.py", line 821, in decode
    hyp = self.attention_rescoring(
  File "/home/aistudio/PaddleSpeech/paddlespeech/s2t/models/u2/u2.py", line 535, in attention_rescoring
    assert speech.shape[0] == speech_lengths.shape[0]
IndexError: list index out of range
Failed in evaluation!

```

@zxcd @Liyulingyue 