### PR TITLE
[Hackathon 7th] 修复 vctk 中 `spk_emb` 维度问题

### DIFF
--- a/paddlespeech/t2s/models/fastspeech2/fastspeech2.py
+++ b/paddlespeech/t2s/models/fastspeech2/fastspeech2.py
@@ -841,9 +841,10 @@ class FastSpeech2(nn.Layer):
             spk_emb = self.spk_projection(F.normalize(spk_emb))
             hs = hs + spk_emb.unsqueeze(1)
         elif self.spk_embed_integration_type == "concat":
-            # concat hidden states with spk embeds and then apply projection
-            if spk_emb.dim() < 2:
+            # one wave `spk_emb` under synthesize, the dim is `1`
+            if spk_emb.dim() == 1:
                 spk_emb = spk_emb.unsqueeze(0)
+            # concat hidden states with spk embeds and then apply projection
             spk_emb = F.normalize(spk_emb).unsqueeze(1).expand(
                 shape=[-1, paddle.shape(hs)[1], -1])
             hs = self.spk_projection(paddle.concat([hs, spk_emb], axis=-1))

--- a/paddlespeech/t2s/models/fastspeech2/fastspeech2.py
+++ b/paddlespeech/t2s/models/fastspeech2/fastspeech2.py
@@ -842,6 +842,8 @@ class FastSpeech2(nn.Layer):
             hs = hs + spk_emb.unsqueeze(1)
         elif self.spk_embed_integration_type == "concat":
             # concat hidden states with spk embeds and then apply projection
+            if spk_emb.dim() < 2:
+                spk_emb = spk_emb.unsqueeze(0)
             spk_emb = F.normalize(spk_emb).unsqueeze(1).expand(
                 shape=[-1, paddle.shape(hs)[1], -1])
             hs = self.spk_projection(paddle.concat([hs, spk_emb], axis=-1))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复 vctk 中 `spk_emb` 维度问题 ~

不修改 dim ，则下面的命令报维度错误：

``` shell
> CUDA_VISIBLE_DEVICES=0,1 ./local/synthesize.sh conf/default.yaml ./output snapshot_iter_1332.pdz
...
Traceback (most recent call last):
  File "/home/aistudio/PaddleSpeech/paddlespeech/t2s/exps/fastspeech2/../synthesize.py", line 281, in <module>
    main()
  File "/home/aistudio/PaddleSpeech/paddlespeech/t2s/exps/fastspeech2/../synthesize.py", line 277, in main
    evaluate(args)
  File "/home/aistudio/PaddleSpeech/paddlespeech/t2s/exps/fastspeech2/../synthesize.py", line 100, in evaluate
    mel = am_inference(
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/nn/layer/layers.py", line 1532, in __call__
    return self.forward(*inputs, **kwargs)
  File "/home/aistudio/PaddleSpeech/paddlespeech/t2s/models/fastspeech2/fastspeech2.py", line 943, in forward
    normalized_mel, d_outs, p_outs, e_outs = self.acoustic_model.inference(
  File "/home/aistudio/PaddleSpeech/paddlespeech/t2s/models/fastspeech2/fastspeech2.py", line 815, in inference
    _, outs, d_outs, p_outs, e_outs, _ = self._forward(
  File "/home/aistudio/PaddleSpeech/paddlespeech/t2s/models/fastspeech2/fastspeech2.py", line 623, in _forward
    hs = self._integrate_with_spk_embed(hs, spk_emb)
  File "/home/aistudio/PaddleSpeech/paddlespeech/t2s/models/fastspeech2/fastspeech2.py", line 859, in _integrate_with_spk_embed
    spk_emb = F.normalize(spk_emb).unsqueeze(1).expand(
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/nn/functional/norm.py", line 107, in normalize
    out = _C_ops.p_norm(x, float(p), axis, epsilon, True, False)
ValueError: (InvalidArgument) Attr(axis) value should be in range [-R, R-1], R is the rank of Input(X). But received axis: 1, R: 1. Current Input(X)'s shape is=[256].
  [Hint: Expected axis < x_rank, but received axis:1 >= x_rank:1.] (at ../paddle/phi/infermeta/unary.cc:3354)

```

修复后，以下命令正常执行（可正常训练，并 synthesize）：

``` shell
> CUDA_VISIBLE_DEVICES=0,1 ./local/train.sh conf/default.yaml ./output
[2024-11-28 05:35:12] [INFO] [fastspeech2_updater.py:236] Evaluate: l1_loss: 0.764606, duration_loss: 0.075403, pitch_loss: 0.073118, energy_loss: 0.066784, loss: 0.979911
[2024-11-28 05:35:12] [INFO] [fastspeech2_updater.py:236] Evaluate: l1_loss: 0.764558, duration_loss: 0.092114, pitch_loss: 0.190829, energy_loss: 0.133041, loss: 1.180542

> CUDA_VISIBLE_DEVICES=0,1 ./local/synthesize.sh conf/default.yaml ./output snapshot_iter_1332.pdz
...
s5_397 done!
s5_398, mel: [180, 80], wave: 54000, time: 86s, Hz: 627.9069767441861, RTF: 38.22222222222222.
s5_398 done!
s5_399, mel: [234, 80], wave: 70200, time: 96s, Hz: 731.25, RTF: 32.82051282051282.
s5_399 done!
s5_400, mel: [157, 80], wave: 47100, time: 85s, Hz: 554.1176470588235, RTF: 43.31210191082803.
s5_400 done!
generation speed: 458.7905774202815Hz, RTF: 52.31144923452616
```

@zxcd @Liyulingyue 