### PR TITLE
[Hackathon 7th] 修复 `librispeech` 中 `asr` 的 `readme`

### DIFF
--- a/examples/librispeech/asr0/README.md
+++ b/examples/librispeech/asr0/README.md
@@ -144,7 +144,7 @@ source path.sh
 bash ./local/data.sh
 CUDA_VISIBLE_DEVICES= ./local/train.sh conf/deepspeech2.yaml deepspeech2
 avg.sh best exp/deepspeech2/checkpoints 1
-CUDA_VISIBLE_DEVICES= ./local/test.sh conf/deepspeech2.yaml exp/deepspeech2/checkpoints/avg_1
+CUDA_VISIBLE_DEVICES= ./local/test.sh conf/deepspeech2.yaml conf/tuning/decode.yaml exp/deepspeech2/checkpoints/avg_1
 ```
 ## Stage 4: Static graph model Export
 This stage is to transform dygraph to static graph.
@@ -185,5 +185,5 @@ wget -nc https://paddlespeech.bj.bcebos.com/datasets/single_wav/en/demo_002_en.w
 ```
 You can train a model by yourself, then you need to prepare an audio file or use the audio demo above, please confirm the sample rate of the audio is 16K. You can get the result of the audio demo by running the script below.
 ```bash
-CUDA_VISIBLE_DEVICES= ./local/test_wav.sh conf/deepspeech2.yaml exp/deepspeech2/checkpoints/avg_1 data/demo_002_en.wav
+CUDA_VISIBLE_DEVICES= ./local/test_wav.sh conf/deepspeech2.yaml conf/tuning/decode.yaml exp/deepspeech2/checkpoints/avg_1 data/demo_002_en.wav
 ```

--- a/examples/librispeech/asr1/README.md
+++ b/examples/librispeech/asr1/README.md
@@ -148,7 +148,7 @@ or you can run these scripts in the command line (only use CPU).
 bash ./local/data.sh
 CUDA_VISIBLE_DEVICES= ./local/train.sh conf/conformer.yaml conformer
 avg.sh best exp/conformer/checkpoints 20
-CUDA_VISIBLE_DEVICES= ./local/test.sh conf/conformer.yaml exp/conformer/checkpoints/avg_20
+CUDA_VISIBLE_DEVICES= ./local/test.sh conf/conformer.yaml conf/tuning/decode.yaml exp/conformer/checkpoints/avg_20
 ```
 ## Pretrained Model
 You can get the pretrained transformer or conformer from [this](../../../docs/source/released_model.md).
@@ -163,7 +163,7 @@ source path.sh
 # If you have process the data and get the manifest file， you can skip the following 2 steps
 bash local/data.sh --stage -1 --stop_stage -1
 bash local/data.sh --stage 2 --stop_stage 2
-CUDA_VISIBLE_DEVICES= ./local/test.sh conf/conformer.yaml exp/conformer/checkpoints/avg_20
+CUDA_VISIBLE_DEVICES= ./local/test.sh conf/conformer.yaml conf/tuning/decode.yaml exp/conformer/checkpoints/avg_20
 ```
 The performance of the released models are shown in [here](./RESULTS.md).
 
@@ -192,8 +192,8 @@ bash ./local/data.sh
 CUDA_VISIBLE_DEVICES= ./local/train.sh conf/conformer.yaml conformer
 avg.sh best exp/conformer/checkpoints 20
 # test stage is optional
-CUDA_VISIBLE_DEVICES= ./local/test.sh conf/conformer.yaml exp/conformer/checkpoints/avg_20
-CUDA_VISIBLE_DEVICES= ./local/align.sh conf/conformer.yaml exp/conformer/checkpoints/avg_20
+CUDA_VISIBLE_DEVICES= ./local/test.sh conf/conformer.yaml conf/tuning/decode.yaml exp/conformer/checkpoints/avg_20
+CUDA_VISIBLE_DEVICES= ./local/align.sh conf/conformer.yaml conf/tuning/decode.yaml exp/conformer/checkpoints/avg_20
 ```
 ## Stage 5: Single Audio File Inference
 In some situations, you want to use the trained model to do the inference for the single audio file. You can use stage 5. The code is shown below
@@ -214,5 +214,5 @@ wget -nc https://paddlespeech.bj.bcebos.com/datasets/single_wav/en/demo_002_en.w
 ```
 You need to prepare an audio file or use the audio demo above, please confirm the sample rate of the audio is 16K. You can get the result of the audio demo by running the script below.
 ```bash
-CUDA_VISIBLE_DEVICES= ./local/test_wav.sh conf/conformer.yaml exp/conformer/checkpoints/avg_20 data/demo_002_en.wav
+CUDA_VISIBLE_DEVICES= ./local/test_wav.sh conf/conformer.yaml conf/tuning/decode.yaml exp/conformer/checkpoints/avg_20 data/demo_002_en.wav
 ```


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复 `librispeech` 中 `asr0` 的 `readme` ~

`librispeech` 中 `asr0` 测试没发现什么问题，除了 test 爆显存了 ～

日志如下：

``` shell

$ bash run.sh --stage 0 --stop_stage 0
checkpoint name deepspeech2
Skip downloading and unpacking. Data already exists in /home/aistudio/PaddleSpeech/dataset/librispeech/test-clean.
Creating manifest data/manifest.test-clean ...
Skip downloading and unpacking. Data already exists in /home/aistudio/PaddleSpeech/dataset/librispeech/train-clean-100.
Creating manifest data/manifest.train-clean-100 ...
Data download and manifest prepare done!
----------- compute_mean_std.py Configuration Arguments -----------
delta_delta: 0
feat_dim: 161
manifest_path: data/manifest.train.raw
num_samples: 2000
num_workers: 24
output_path: data/mean_std.json
sample_rate: 16000
spectrum_type: fbank
stride_ms: 10
target_dB: -20
use_dB_normalization: 0
window_ms: 25
-----------------------------------------------------------
2024-11-28 13:42:30.187 | INFO     | paddlespeech.s2t.frontend.augmentor.augmentation:__init__:122 - Augmentation: []
----------- build_vocab.py Configuration Arguments -----------
count_threshold: 0
manifest_paths: ['data/manifest.train.raw']
spm_character_coverage: 0.9995
spm_mode: unigram
spm_model_prefix: 
spm_vocab_size: 0
text_keys: text
unit_type: char
vocab_path: data/lang_char/vocab.txt
-----------------------------------------------------------
2024-11-28 13:42:57.272 | WARNING  | paddlespeech.s2t.frontend.featurizer.text_featurizer:__init__:58 - TextFeaturizer: not have vocab file or vocab list. Only Tokenizer can use, can not convert to token idx
----------- format_data.py Configuration Arguments -----------
cmvn_path: data/mean_std.json
manifest_paths: ['data/manifest.dev.raw']
output_path: data/manifest.dev
spm_model_prefix: None
unit_type: char
vocab_path: data/lang_char/vocab.txt
-----------------------------------------------------------
Feature dim: 161
Vocab size: 31
----------- format_data.py Configuration Arguments -----------
cmvn_path: data/mean_std.json
manifest_paths: ['data/manifest.test.raw']
output_path: data/manifest.test
spm_model_prefix: None
unit_type: char
vocab_path: data/lang_char/vocab.txt
-----------------------------------------------------------
Feature dim: 161
----------- format_data.py Configuration Arguments -----------
cmvn_path: data/mean_std.json
manifest_paths: ['data/manifest.dev-clean.raw']
output_path: data/manifest.dev-clean
spm_model_prefix: None
unit_type: char
vocab_path: data/lang_char/vocab.txt
-----------------------------------------------------------
Vocab size: 31
Feature dim: 161
Vocab size: 31
----------- format_data.py Configuration Arguments -----------
cmvn_path: data/mean_std.json
manifest_paths: ['data/manifest.train.raw']
output_path: data/manifest.train
spm_model_prefix: None
unit_type: char
vocab_path: data/lang_char/vocab.txt
-----------------------------------------------------------
----------- format_data.py Configuration Arguments -----------
cmvn_path: data/mean_std.json
manifest_paths: ['data/manifest.test-clean.raw']
output_path: data/manifest.test-clean
spm_model_prefix: None
unit_type: char
vocab_path: data/lang_char/vocab.txt
-----------------------------------------------------------
Feature dim: 161
Feature dim: 161
Vocab size: 31
Vocab size: 31
['data/manifest.dev.raw'] Examples number: 2620
['data/manifest.test-clean.raw'] Examples number: 2620
['data/manifest.test.raw'] Examples number: 2620
['data/manifest.dev-clean.raw'] Examples number: 2703
['data/manifest.train.raw'] Examples number: 28539
LibriSpeech Data preparation done.


$ bash run.sh --stage 1 --stop_stage 1

2024-11-28 13:48:09.327 | INFO     | paddlespeech.s2t.training.trainer:do_train:312 - Train: Rank: 0, epoch: 0, step: 4, lr: 0.00050000, train_loss: 1773.05566406, batch_size: 64, accum: 1, step_cost: 0.95885801, iter: 5, total: 781, reader_cost: 0.00070810, batch_cost: 0.95956612, samples: 64, ips samples/s: 66.69681110
2024-11-28 13:48:10.170 | INFO     | paddlespeech.s2t.training.trainer:do_train:312 - Train: Rank: 0, epoch: 0, step: 5, lr: 0.00050000, train_loss: 1236.55541992, batch_size: 64, accum: 1, step_cost: 0.84070730, iter: 6, total: 781, reader_cost: 0.00068378, batch_cost: 0.84139109, samples: 64, ips samples/s: 76.06450915
2024-11-28 13:48:11.076 | INFO     | paddlespeech.s2t.training.trainer:do_train:312 - Train: Rank: 0, epoch: 0, step: 6, lr: 0.00050000, train_loss: 1194.93554688, batch_size: 64, accum: 1, step_cost: 0.90384078, iter: 7, total: 781, reader_cost: 0.00056148, batch_cost: 0.90440226, samples: 64, ips samples/s: 70.76497164
2024-11-28 13:48:11.960 | INFO     | paddlespeech.s2t.training.trainer:do_train:312 - Train: Rank: 0, epoch: 0, step: 7, lr: 0.00050000, train_loss: 956.93420410, batch_size: 64, accum: 1, step_cost: 0.88279843, iter: 8, total: 781, reader_cost: 0.00045705, batch_cost: 0.88325548, samples: 64, ips samples/s: 72.45921630


$ CUDA_VISIBLE_DEVICES=0,1 ./local/train.sh conf/deepspeech2.yaml deepspeech2
2024-11-28 14:42:59.394 | INFO     | paddlespeech.s2t.exps.deepspeech2.model:valid:122 - Valid: Rank: 0, epoch: 1, step: 3102, batch : 83/85, val_loss: 309.342262, val_history_loss: 309.225837
2024-11-28 14:42:59.437 | INFO     | paddlespeech.s2t.exps.deepspeech2.model:valid:122 - Valid: Rank: 0, epoch: 1, step: 3102, batch : 84/85, val_loss: 306.512609, val_history_loss: 306.398621
2024-11-28 14:42:59.466 | INFO     | paddlespeech.s2t.exps.deepspeech2.model:valid:122 - Valid: Rank: 0, epoch: 1, step: 3102, batch : 85/85, val_loss: 303.368973, val_history_loss: 304.916955
2024-11-28 14:42:59.717 | INFO     | paddlespeech.s2t.exps.deepspeech2.model:valid:124 - Rank 0 Val info val_loss 304.91695469935263
2024-11-28 14:42:59.720 | INFO     | paddlespeech.s2t.training.timer:__exit__:44 - Eval Time Cost: 0:00:35.679357
Epoch 2: ExponentialDecay set learning rate to 0.0004324500000000001.
2024-11-28 14:42:59.720 | INFO     | paddlespeech.s2t.training.trainer:do_train:331 - Epoch 1 Val info val_loss 304.9169616699219
2024-11-28 14:43:03.666 | INFO     | paddlespeech.s2t.utils.checkpoint:_save_parameters:286 - Saved model to exp/deepspeech2/checkpoints/1.pdparams
2024-11-28 14:43:07.054 | INFO     | paddlespeech.s2t.utils.checkpoint:_save_parameters:292 - Saved optimzier state to exp/deepspeech2/checkpoints/1.pdopt
2024-11-28 14:43:16.665 | INFO     | paddlespeech.s2t.utils.checkpoint:_save_parameters:286 - Saved model to exp/deepspeech2/checkpoints/1.pdparams
2024-11-28 14:43:25.648 | INFO     | paddlespeech.s2t.utils.checkpoint:_save_parameters:292 - Saved optimzier state to exp/deepspeech2/checkpoints/1.pdopt
2024-11-28 14:43:25.650 | INFO     | paddlespeech.s2t.training.timer:__exit__:44 - Training Done: 0:36:14.602415
I1128 14:43:26.291289 94665 process_group_nccl.cc:155] ProcessGroupNCCL destruct 
I1128 14:43:26.803676 94720 tcp_store.cc:290] receive shutdown event and so quit from MasterDaemon run loop
LAUNCH INFO 2024-11-28 14:43:28,111 Pod completed
LAUNCH INFO 2024-11-28 14:43:28,112 Exit code 0


$ avg.sh best exp/deepspeech2/checkpoints 1
Namespace(ckpt_dir='exp/deepspeech2/checkpoints', dst_model='exp/deepspeech2/checkpoints/avg_1.pdparams', max_epoch=65536, min_epoch=0, num=1, val_best=True)
selected val scores = [304.91696167]
selected epochs = [1]
averaged val score = 304.9169616699219
['exp/deepspeech2/checkpoints/1.pdparams']
Processing exp/deepspeech2/checkpoints/1.pdparams
Saving to exp/deepspeech2/checkpoints/avg_1.pdparams

但是爆显存了 ～
$ CUDA_VISIBLE_DEVICES=0 ./local/test.sh conf/deepspeech2.yaml conf/tuning/decode.yaml exp/deepspeech2/checkpoints/avg_1
...
2024-11-28 14:51:49.220 | INFO     | paddlespeech.s2t.utils.layer_tools:print_params:57 - encoder.layernorm_list.4.bias | [2048] | 2048 | True
2024-11-28 14:51:49.220 | INFO     | paddlespeech.s2t.utils.layer_tools:print_params:57 - decoder.ctc_lo.weight | [2048, 31] | 63488 | True
2024-11-28 14:51:49.220 | INFO     | paddlespeech.s2t.utils.layer_tools:print_params:57 - decoder.ctc_lo.bias | [31] | 31 | True
2024-11-28 14:51:49.221 | INFO     | paddlespeech.s2t.utils.layer_tools:print_params:60 - Total parameters: 58.0, 113.96M elements.
2024-11-28 14:51:49.221 | INFO     | paddlespeech.s2t.exps.deepspeech2.model:setup_model:145 - Setup model!
2024-11-28 14:51:50.880 | INFO     | paddlespeech.s2t.utils.checkpoint:load_parameters:117 - Rank 0: Restore model from exp/deepspeech2/checkpoints/avg_1.pdparams
2024-11-28 14:51:50.882 | INFO     | paddlespeech.s2t.exps.deepspeech2.model:test:296 - Test Total Examples: 21
2024-11-28 14:51:50.882 | INFO     | paddlespeech.s2t.modules.ctc:_init_ext_scorer:190 - begin to initialize the external scorer for decoding
2024-11-28 14:52:04.212 | INFO     | paddlespeech.s2t.modules.ctc:_init_ext_scorer:197 - language model: is_character_based = 0, max_order = 5, dict_size = 400000
2024-11-28 14:52:04.367 | INFO     | paddlespeech.s2t.modules.ctc:_init_ext_scorer:201 - end initializing scorer
2024-11-28 14:52:42.571 | INFO     | paddlespeech.s2t.training.timer:__exit__:44 - Test/Decode Done: 0:00:53.349784


> CUDA_VISIBLE_DEVICES=0 ./local/test_wav.sh conf/deepspeech2.yaml conf/tuning/decode.yaml exp/deepspeech2/checkpoints/avg_1 data/demo_002_en.wav
2024-11-28 14:55:42.373 | INFO     | __main__:test:72 - audio shape: (130892,)
2024-11-28 14:55:42.721 | INFO     | __main__:test:76 - feat shape: (816, 161)
2024-11-28 14:55:42.722 | INFO     | paddlespeech.s2t.modules.ctc:_init_ext_scorer:190 - begin to initialize the external scorer for decoding
2024-11-28 14:55:56.228 | INFO     | paddlespeech.s2t.modules.ctc:_init_ext_scorer:197 - language model: is_character_based = 0, max_order = 5, dict_size = 400000
2024-11-28 14:55:56.382 | INFO     | paddlespeech.s2t.modules.ctc:_init_ext_scorer:201 - end initializing scorer
2024-11-28 14:55:57.626 | INFO     | __main__:test:84 - result_transcripts: heterogeneity


```

@zxcd @Liyulingyue 