### PR TITLE
[Hackathon 7th] t2s inference compatible with PIR api

### DIFF
--- a/paddlespeech/t2s/exps/inference.py
+++ b/paddlespeech/t2s/exps/inference.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import os
 from pathlib import Path
 
 import paddle
@@ -120,6 +121,15 @@ def parse_args():
     return args
 
 
+def get_model_suffix(inference_dir, model_name):
+    if os.path.exists(os.path.join(inference_dir, model_name + ".pdmodel")):
+        return ".pdmodel"
+    elif os.path.exists(os.path.join(inference_dir, model_name + ".json")):
+        return ".json"
+    else:
+        raise ValueError("model file not found!")
+
+
 # only inference for models trained with csmsc now
 def main():
     args = parse_args()
@@ -133,9 +143,10 @@ def main():
         tones_dict=args.tones_dict)
 
     # am_predictor
+    suffix = get_model_suffix(args.inference_dir, args.am)
     am_predictor = get_predictor(
         model_dir=args.inference_dir,
-        model_file=args.am + ".pdmodel",
+        model_file=args.am + suffix,
         params_file=args.am + ".pdiparams",
         device=args.device,
         use_trt=args.use_trt,
@@ -146,9 +157,10 @@ def main():
     am_dataset = args.am[args.am.rindex('_') + 1:]
 
     # voc_predictor
+    suffix = get_model_suffix(args.inference_dir, args.voc)
     voc_predictor = get_predictor(
         model_dir=args.inference_dir,
-        model_file=args.voc + ".pdmodel",
+        model_file=args.voc + suffix,
         params_file=args.voc + ".pdiparams",
         device=args.device,
         use_trt=args.use_trt,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 

### Describe
<!-- Describe what this PR does -->
This pull request includes changes to the `paddlespeech/t2s/exps/inference.py` file to enhance the flexibility of model file handling. The most important changes involve importing the `os` module, adding a new function to determine the model file suffix, and updating the `main` function to use the new logic for model file suffixes.

Enhancements to model file handling:

* [`paddlespeech/t2s/exps/inference.py`](diffhunk://#diff-0bec946f8508a4fd06f6041cefa0385275d1b6e72ae225e7b4946add474bdfdeR15): Imported the `os` module to enable file existence checks.
* [`paddlespeech/t2s/exps/inference.py`](diffhunk://#diff-0bec946f8508a4fd06f6041cefa0385275d1b6e72ae225e7b4946add474bdfdeR124-R132): Added `get_model_suffix` function to determine the appropriate suffix for model files based on their existence in the specified directory.
* [`paddlespeech/t2s/exps/inference.py`](diffhunk://#diff-0bec946f8508a4fd06f6041cefa0385275d1b6e72ae225e7b4946add474bdfdeR146-R149): Updated the `main` function to use the `get_model_suffix` function for determining the suffix of the `am` and `voc` model files dynamically. [[1]](diffhunk://#diff-0bec946f8508a4fd06f6041cefa0385275d1b6e72ae225e7b4946add474bdfdeR146-R149) [[2]](diffhunk://#diff-0bec946f8508a4fd06f6041cefa0385275d1b6e72ae225e7b4946add474bdfdeR160-R163)
