### PR TITLE
[Hackathon 7th] 修复 paddle 3.0 `transpose` 的输入不能为 `tensor` 的问题

### DIFF
--- a/paddlespeech/s2t/models/wav2vec2/modules/wav2vec2_model.py
+++ b/paddlespeech/s2t/models/wav2vec2/modules/wav2vec2_model.py
@@ -1267,7 +1267,7 @@ class TransposeLast(nn.Layer):
     def forward(self, x):
         if self.deconstruct_idx is not None:
             x = x[self.deconstruct_idx]
-        trans_dim = paddle.arange(x.dim())
+        trans_dim = np.arange(x.dim())
         trans_dim[-1], trans_dim[-2] = trans_dim[-2], trans_dim[-1]
         return x.transpose(trans_dim)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
修复 paddle 3.0 `transpose` 的输入不能为 `tensor` 的问题(2.5.1 支持 tensor 输入）～

错误日志：

``` shell

/home/aistudio/PaddleSpeech/paddlespeech/s2t/exps/hubert/bin/train.py", line 32, in main
    main_sp(config, args)
  File "/home/aistudio/PaddleSpeech/paddlespeech/s2t/exps/hubert/bin/train.py", line 28, in main_sp
    exp.run()
  File "/home/aistudio/PaddleSpeech/paddlespeech/s2t/training/trainer.py", line 351, in run
    self.do_train()
  File "/home/aistudio/PaddleSpeech/paddlespeech/s2t/exps/hubert/model.py", line 457, in do_train
    raise e
  File "/home/aistudio/PaddleSpeech/paddlespeech/s2t/exps/hubert/model.py", line 433, in do_train
    self.train_batch(batch_index, batch, msg)
  File "/home/aistudio/PaddleSpeech/paddlespeech/s2t/exps/hubert/model.py", line 193, in train_batch
    loss = self.model(wav, wavs_lens_rate, target, target_lens)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/nn/layer/layers.py", line 1531, in __call__
    return self.forward(*inputs, **kwargs)
  File "/home/aistudio/PaddleSpeech/paddlespeech/s2t/models/hubert/hubert_ASR.py", line 90, in forward
    out = self.hubert.extract_features(wav)[0]
  File "/home/aistudio/PaddleSpeech/paddlespeech/s2t/models/hubert/modules/hubert_model.py", line 548, in extract_features
    res = self.forward(
  File "/home/aistudio/PaddleSpeech/paddlespeech/s2t/models/hubert/modules/hubert_model.py", line 445, in forward
    features = self.forward_features(source)
  File "/home/aistudio/PaddleSpeech/paddlespeech/s2t/models/hubert/modules/hubert_model.py", line 405, in forward_features
    features = self.feature_extractor(source)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/nn/layer/layers.py", line 1531, in __call__
    return self.forward(*inputs, **kwargs)
  File "/home/aistudio/PaddleSpeech/paddlespeech/s2t/models/wav2vec2/modules/wav2vec2_model.py", line 2332, in forward
    x = conv(x)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/nn/layer/layers.py", line 1531, in __call__
    return self.forward(*inputs, **kwargs)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/nn/layer/container.py", line 754, in forward
    input = layer(input)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/nn/layer/layers.py", line 1531, in __call__
    return self.forward(*inputs, **kwargs)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/nn/layer/container.py", line 754, in forward
    input = layer(input)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/nn/layer/layers.py", line 1531, in __call__
    return self.forward(*inputs, **kwargs)
  File "/home/aistudio/PaddleSpeech/paddlespeech/s2t/models/wav2vec2/modules/wav2vec2_model.py", line 1277, in forward
    return x.transpose(trans_dim)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/tensor/linalg.py", line 127, in transpose
    return _C_ops.transpose(x, perm)
TypeError: (InvalidType) transpose(): argument (position 2) must be list or tuple, but got Tensor (at ../paddle/fluid/pybind/op_function_common.cc:592)

```

@zxcd @Liyulingyue @enkilee @GreatV 