### PR TITLE
[Hackathon 7th] 修复 `asr4` 测试命令中重复的 `arg`

### DIFF
--- a/paddlespeech/s2t/exps/hubert/bin/test.py
+++ b/paddlespeech/s2t/exps/hubert/bin/test.py
@@ -37,8 +37,6 @@ if __name__ == "__main__":
     # save asr result to
     parser.add_argument(
         '--dict-path', type=str, default=None, help='dict path.')
-    parser.add_argument(
-        "--result_file", type=str, help="path of save the asr result")
     args = parser.parse_args()
     print_arguments(args, globals())
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复 `asr4` 测试命令中重复的 `arg`

@zxcd @Liyulingyue 