### PR TITLE
[Hackathon 7th] 使用 `reshape` 代替 `view`

### DIFF
--- a/audio/paddleaudio/utils/tensor_utils.py
+++ b/audio/paddleaudio/utils/tensor_utils.py
@@ -177,8 +177,9 @@ def th_accuracy(pad_outputs: paddle.Tensor,
     Returns:
         float: Accuracy value (0.0 - 1.0).
     """
-    pad_pred = pad_outputs.view(pad_targets.shape[0], pad_targets.shape[1],
-                                pad_outputs.shape[1]).argmax(2)
+    pad_pred = pad_outputs.reshape(
+        [pad_targets.shape[0], pad_targets.shape[1],
+         pad_outputs.shape[1]]).argmax(2)
     mask = pad_targets != ignore_label
     #TODO(Hui Zhang): sum not support bool type
     # numerator = paddle.sum(

--- a/paddlespeech/s2t/decoders/scorers/scorer_interface.py
+++ b/paddlespeech/s2t/decoders/scorers/scorer_interface.py
@@ -135,7 +135,7 @@ class BatchScorerInterface(ScorerInterface):
             score, outstate = self.score(y, state, x)
             outstates.append(outstate)
             scores.append(score)
-        scores = paddle.cat(scores, 0).view(ys.shape[0], -1)
+        scores = paddle.cat(scores, 0).reshape([ys.shape[0], -1])
         return scores, outstates
 
 

--- a/paddlespeech/s2t/models/hubert/hubert_ASR.py
+++ b/paddlespeech/s2t/models/hubert/hubert_ASR.py
@@ -213,7 +213,7 @@ class HubertASR(nn.Layer):
         x_lens = x.shape[1]
         ctc_probs = self.ctc.log_softmax(x)  # (B, maxlen, vocab_size)
         topk_prob, topk_index = ctc_probs.topk(1, axis=2)  # (B, maxlen, 1)
-        topk_index = topk_index.view(batch_size, x_lens)  # (B, maxlen)
+        topk_index = topk_index.reshape([batch_size, x_lens])  # (B, maxlen)
 
         hyps = [hyp.tolist() for hyp in topk_index]
         hyps = [remove_duplicates_and_blank(hyp) for hyp in hyps]

--- a/paddlespeech/s2t/models/lm/transformer.py
+++ b/paddlespeech/s2t/models/lm/transformer.py
@@ -122,10 +122,12 @@ class TransformerLM(nn.Layer, LMInterface, BatchScorerInterface):
         h, _ = self.encoder(emb, xlen)
         y = self.decoder(h)
         loss = F.cross_entropy(
-            y.view(-1, paddle.shape(y)[-1]), t.view(-1), reduction="none")
+            y.reshape([-1, paddle.shape(y)[-1]]),
+            t.reshape([-1]),
+            reduction="none")
         mask = xm.to(loss.dtype)
-        logp = loss * mask.view(-1)
-        nll = logp.view(batch_size, -1).sum(-1)
+        logp = loss * mask.reshape([-1])
+        nll = logp.reshape([batch_size, -1]).sum(-1)
         nll_count = mask.sum(-1)
         logp = logp.sum()
         count = mask.sum()

--- a/paddlespeech/s2t/models/u2_st/u2_st.py
+++ b/paddlespeech/s2t/models/u2_st/u2_st.py
@@ -176,7 +176,7 @@ class U2STBaseModel(nn.Layer):
         # 2. Compute attention loss
         loss_att = self.criterion_att(decoder_out, ys_out_pad)
         acc_att = th_accuracy(
-            decoder_out.view(-1, self.vocab_size),
+            decoder_out.reshape([-1, self.vocab_size]),
             ys_out_pad,
             ignore_label=self.ignore_id, )
         return loss_att, acc_att
@@ -209,7 +209,7 @@ class U2STBaseModel(nn.Layer):
         # 2. Compute attention loss
         loss_att = self.criterion_att(decoder_out, ys_out_pad)
         acc_att = th_accuracy(
-            decoder_out.view(-1, self.vocab_size),
+            decoder_out.reshape([-1, self.vocab_size]),
             ys_out_pad,
             ignore_label=self.ignore_id, )
         return loss_att, acc_att

--- a/paddlespeech/s2t/models/wavlm/wavlm_asr.py
+++ b/paddlespeech/s2t/models/wavlm/wavlm_asr.py
@@ -188,7 +188,7 @@ class WavLMASR(nn.Layer):
         x_lens = x.shape[1]
         ctc_probs = self.ctc.log_softmax(x)  # (B, maxlen, vocab_size)
         topk_prob, topk_index = ctc_probs.topk(1, axis=2)  # (B, maxlen, 1)
-        topk_index = topk_index.view(batch_size, x_lens)  # (B, maxlen)
+        topk_index = topk_index.reshape([batch_size, x_lens])  # (B, maxlen)
 
         hyps = [hyp.tolist() for hyp in topk_index]
         hyps = [remove_duplicates_and_blank(hyp) for hyp in hyps]

--- a/paddlespeech/s2t/models/wavlm/wavlm_paddle.py
+++ b/paddlespeech/s2t/models/wavlm/wavlm_paddle.py
@@ -297,8 +297,8 @@ class WavLM(nn.Layer):
         extra = padding_mask.size(1) % features.size(1)
         if extra > 0:
             padding_mask = padding_mask[:, :-extra]
-        padding_mask = padding_mask.view(
-            padding_mask.size(0), features.size(1), -1)
+        padding_mask = padding_mask.reshape(
+            [padding_mask.size(0), features.size(1), -1])
         padding_mask = padding_mask.all(-1)
         return padding_mask
 
@@ -475,14 +475,15 @@ class ConvFeatureExtractionModel(nn.Layer):
                 else:
                     x = conv(x)
             x = x.transpose([0, 1, 3, 2]).contiguous()
-            x = x.view(x.size(0), -1, x.size(-1))
+            x = x.reshape([x.size(0), -1, x.size(-1)])
         else:
             for conv in self.conv_layers:
                 x = conv(x)
             if self.conv_type == "conv2d":
                 b, c, t, f = x.size()
-                # x = x.transpose(2, 3).contiguous().view(b, c * f, t)
-                x = x.transpose([0, 1, 3, 2]).contiguous().view(b, c * f, t)
+                # x = x.transpose(2, 3).contiguous().reshape([b, c * f, t])
+                x = x.transpose([0, 1, 3, 2]).contiguous().reshape(
+                    [b, c * f, t])
         return x
 
 

--- a/paddlespeech/s2t/utils/tensor_utils.py
+++ b/paddlespeech/s2t/utils/tensor_utils.py
@@ -181,8 +181,9 @@ def th_accuracy(pad_outputs: paddle.Tensor,
     Returns:
         float: Accuracy value (0.0 - 1.0).
     """
-    pad_pred = pad_outputs.view(pad_targets.shape[0], pad_targets.shape[1],
-                                pad_outputs.shape[1]).argmax(2)
+    pad_pred = pad_outputs.reshape(
+        [pad_targets.shape[0], pad_targets.shape[1],
+         pad_outputs.shape[1]]).argmax(2)
     mask = pad_targets != ignore_label
 
     numerator = paddle.sum(

--- a/paddlespeech/t2s/models/jets/generator.py
+++ b/paddlespeech/t2s/models/jets/generator.py
@@ -751,10 +751,10 @@ class JETSGenerator(nn.Layer):
 
         # integrate with SID and LID embeddings
         if self.spks is not None:
-            sid_embs = self.sid_emb(sids.view(-1))
+            sid_embs = self.sid_emb(sids.reshape([-1]))
             hs = hs + sid_embs.unsqueeze(1)
         if self.langs is not None:
-            lid_embs = self.lid_emb(lids.view(-1))
+            lid_embs = self.lid_emb(lids.reshape([-1]))
             hs = hs + lid_embs.unsqueeze(1)
 
         # integrate speaker embedding


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
paddlespeech 之前使用的 patch 方法：

``` python

def view(xs: paddle.Tensor, *args: int) -> paddle.Tensor:
    return xs.reshape(args)


if not hasattr(paddle.Tensor, 'view'):
    logger.debug("register user view to paddle.Tensor, remove this when fixed!")
    paddle.Tensor.view = view
    paddle.static.Variable.view = view

```

在使用时为：

``` python

x.view(a,b,c)

``` 

的调用方式，但是 paddle 2.6 引入的 `paddle.Tensor.view` ，其用法为：

``` python

x.view([a,b,c])

```

由此，导致接口不兼容。

特此，将所有涉及的接口改为 `reshape`，并修改输入为 `list` 的方式。

@zxcd @Liyulingyue @GreatV @enkilee @yinfan98 