### PR TITLE
[Hackathon 7th] 修复 `asr5` 的 `test.sh` 脚本路径错误

### DIFF
--- a/examples/librispeech/asr5/local/test.sh
+++ b/examples/librispeech/asr5/local/test.sh
@@ -23,7 +23,7 @@ source ${MAIN_ROOT}/utils/parse_options.sh || exit 1;
 #    exit 1
 #fi
 
-python3 format_rsl.py \
+python3 ${MAIN_ROOT}/paddlespeech/dataset/s2t/format_rsl.py \
     --origin_ref data/manifest.test-clean.raw \
     --trans_ref data/manifest.test-clean.text
 
@@ -44,7 +44,7 @@ for type in ctc_greedy_search; do
         echo "Failed in evaluation!"
         exit 1
     fi
-    python3 format_rsl.py \
+    python3 ${MAIN_ROOT}/paddlespeech/dataset/s2t/format_rsl.py \
         --origin_hyp ${ckpt_prefix}.${type}.rsl \
         --trans_hyp ${ckpt_prefix}.${type}.rsl.text
 
@@ -69,7 +69,7 @@ for type in ctc_prefix_beam_search; do
         echo "Failed in evaluation!"
         exit 1
     fi
-    python3 format_rsl.py \
+    python3 ${MAIN_ROOT}/paddlespeech/dataset/s2t/format_rsl.py \
         --origin_hyp ${ckpt_prefix}.${type}.rsl \
         --trans_hyp ${ckpt_prefix}.${type}.rsl.text
 

--- a/examples/librispeech/asr5/local/test.sh
+++ b/examples/librispeech/asr5/local/test.sh
@@ -23,7 +23,7 @@ source ${MAIN_ROOT}/utils/parse_options.sh || exit 1;
 #    exit 1
 #fi
 
-python3 ${MAIN_ROOT}/paddlespeech/dataset/s2t/format_rsl.py \
+python3 ${MAIN_ROOT}/utils/format_rsl.py \
     --origin_ref data/manifest.test-clean.raw \
     --trans_ref data/manifest.test-clean.text
 
@@ -44,7 +44,7 @@ for type in ctc_greedy_search; do
         echo "Failed in evaluation!"
         exit 1
     fi
-    python3 ${MAIN_ROOT}/paddlespeech/dataset/s2t/format_rsl.py \
+    python3 ${MAIN_ROOT}/utils/format_rsl.py \
         --origin_hyp ${ckpt_prefix}.${type}.rsl \
         --trans_hyp ${ckpt_prefix}.${type}.rsl.text
 
@@ -69,7 +69,7 @@ for type in ctc_prefix_beam_search; do
         echo "Failed in evaluation!"
         exit 1
     fi
-    python3 ${MAIN_ROOT}/paddlespeech/dataset/s2t/format_rsl.py \
+    python3 ${MAIN_ROOT}/utils/format_rsl.py \
         --origin_hyp ${ckpt_prefix}.${type}.rsl \
         --trans_hyp ${ckpt_prefix}.${type}.rsl.text
 

--- a/paddlespeech/s2t/exps/wavlm/bin/test.py
+++ b/paddlespeech/s2t/exps/wavlm/bin/test.py
@@ -18,7 +18,8 @@ from yacs.config import CfgNode
 
 from paddlespeech.s2t.exps.wavlm.model import WavLMASRTester as Tester
 from paddlespeech.s2t.training.cli import default_argument_parser
-from paddlespeech.utils.argparse import print_arguments, add_arguments
+from paddlespeech.utils.argparse import add_arguments
+from paddlespeech.utils.argparse import print_arguments
 
 
 def main_sp(config, args):
@@ -37,8 +38,6 @@ if __name__ == "__main__":
     # save asr result to
     parser.add_argument(
         '--dict-path', type=str, default=None, help='dict path.')
-    parser.add_argument(
-        "--result_file", type=str, help="path of save the asr result")
     args = parser.parse_args()
     print_arguments(args, globals())
 

--- a/paddlespeech/s2t/exps/wavlm/bin/test_wav.py
+++ b/paddlespeech/s2t/exps/wavlm/bin/test_wav.py
@@ -105,10 +105,6 @@ def main(config, args):
 if __name__ == "__main__":
     parser = default_argument_parser()
     # save asr result to
-    parser.add_argument(
-        "--result_file", type=str, help="path of save the asr result")
-    parser.add_argument(
-        "--audio_file", type=str, help="path of the input audio file")
     args = parser.parse_args()
 
     config = CfgNode(new_allowed=True)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复 `asr5` 的 `test.sh` 脚本路径错误

@zxcd @Liyulingyue 