### PR TITLE
[Hackathon 7th] 修复 `vctk` 的 `ernie_sat` 训练时出现的类型提升问题

### DIFF
--- a/paddlespeech/t2s/modules/losses.py
+++ b/paddlespeech/t2s/modules/losses.py
@@ -1115,7 +1115,8 @@ class MLMLoss(nn.Layer):
                     paddle.reshape(xs_pad, (-1, self.odim))),
                 axis=-1)
         mlm_loss = paddle.sum((loss * paddle.reshape(
-            mlm_loss_pos, [-1]))) / paddle.sum((mlm_loss_pos) + 1e-10)
+            mlm_loss_pos.astype(loss.dtype),
+            [-1]))) / paddle.sum((mlm_loss_pos.astype(loss.dtype)) + 1e-10)
 
         text_mlm_loss = None
 

--- a/paddlespeech/t2s/modules/losses.py
+++ b/paddlespeech/t2s/modules/losses.py
@@ -1114,9 +1114,9 @@ class MLMLoss(nn.Layer):
                     paddle.reshape(after_outs, (-1, self.odim)),
                     paddle.reshape(xs_pad, (-1, self.odim))),
                 axis=-1)
+        mlm_loss_pos = (mlm_loss_pos).astype(loss.dtype)
         mlm_loss = paddle.sum((loss * paddle.reshape(
-            mlm_loss_pos.astype(loss.dtype),
-            [-1]))) / paddle.sum((mlm_loss_pos.astype(loss.dtype)) + 1e-10)
+            mlm_loss_pos, [-1]))) / paddle.sum((mlm_loss_pos) + 1e-10)
 
         text_mlm_loss = None
 

--- a/paddlespeech/t2s/modules/nets_utils.py
+++ b/paddlespeech/t2s/modules/nets_utils.py
@@ -466,7 +466,7 @@ def phones_masking(xs_pad: paddle.Tensor,
                 for s, e in zip(masked_start, masked_end):
                     masked_pos[idx, s:e] = 1
     non_eos_mask = paddle.reshape(src_mask, paddle.shape(xs_pad)[:2])
-    masked_pos = masked_pos * non_eos_mask
+    masked_pos = masked_pos * non_eos_mask.astype(masked_pos.dtype)
     masked_pos = paddle.cast(masked_pos, 'bool')
 
     return masked_pos


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复 `vctk` 的 `ernie_sat` 训练时出现的类型提升问题：

``` shell

aistudio@jupyter-942478-8626068:~/PaddleSpeech/examples/vctk/ernie_sat$ CUDA_VISIBLE_DEVICES=0,1 ./local/train.sh conf/default.yaml ./output
...

Traceback (most recent call last):
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/distributed/spawn.py", line 385, in _func_wrapper
    result = func(*args)
  File "/home/aistudio/PaddleSpeech/paddlespeech/t2s/exps/ernie_sat/train.py", line 167, in train_sp
    trainer.run()
  File "/home/aistudio/PaddleSpeech/paddlespeech/t2s/training/trainer.py", line 203, in run
    six.reraise(*exc_info)
  File "/usr/lib/python3/dist-packages/six.py", line 703, in reraise
    raise value
  File "/home/aistudio/PaddleSpeech/paddlespeech/t2s/training/trainer.py", line 149, in run
    update()
  File "/home/aistudio/PaddleSpeech/paddlespeech/t2s/training/updaters/standard_updater.py", line 110, in update
    self.update_core(batch)
  File "/home/aistudio/PaddleSpeech/paddlespeech/t2s/models/ernie_sat/ernie_sat_updater.py", line 70, in update_core
    mlm_loss, text_mlm_loss = self.criterion(
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/nn/layer/layers.py", line 1531, in __call__
    return self.forward(*inputs, **kwargs)
  File "/home/aistudio/PaddleSpeech/paddlespeech/t2s/modules/losses.py", line 1121, in forward
    mlm_loss = paddle.sum((loss * paddle.reshape(
TypeError: (InvalidType) Type promotion only support calculations between floating-point numbers and between complex and real numbers. But got different data type x: float32, y: bool. (at ../paddle/phi/common/type_promotion.h:234)

```

@zxcd @Liyulingyue @GreatV @enkilee @yinfan98 