### PR TITLE
[Hackathon 7th] 修复 `voxceleb` 的类型提升问题

### DIFF
--- a/paddlespeech/vector/io/signal_processing.py
+++ b/paddlespeech/vector/io/signal_processing.py
@@ -37,7 +37,7 @@ def compute_amplitude(waveforms, lengths=None, amp_type="avg", scale="linear"):
             out = paddle.mean(paddle.abs(waveforms), axis=1, keepdim=True)
         else:
             wav_sum = paddle.sum(paddle.abs(waveforms), axis=1, keepdim=True)
-            out = wav_sum / lengths
+            out = wav_sum / lengths.astype(wav_sum.dtype)
     elif amp_type == "peak":
         out = paddle.max(paddle.abs(waveforms), axis=1, keepdim=True)
     else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复 `voxceleb` 的类型提升问题。

错误日志

``` shell
Traceback (most recent call last):
  File "/home/aistudio/PaddleSpeech/paddlespeech/vector/exps/ecapa_tdnn/train.py", line 366, in <module>
    main(args, config)
  File "/home/aistudio/PaddleSpeech/paddlespeech/vector/exps/ecapa_tdnn/train.py", line 175, in main
    waveforms = waveform_augment(waveforms, augment_pipeline)
  File "/home/aistudio/PaddleSpeech/paddlespeech/vector/io/augment.py", line 896, in waveform_augment
    waveforms_aug = aug(waveforms)  # (N, L)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/nn/layer/layers.py", line 1531, in __call__
    return self.forward(*inputs, **kwargs)
  File "/home/aistudio/PaddleSpeech/paddlespeech/vector/io/augment.py", line 772, in forward
    waveforms = self.drop_chunk(waveforms, lengths)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/nn/layer/layers.py", line 1531, in __call__
    return self.forward(*inputs, **kwargs)
  File "/home/aistudio/PaddleSpeech/paddlespeech/vector/io/augment.py", line 141, in forward
    clean_amplitude = compute_amplitude(waveforms, lengths.unsqueeze(1))
  File "/home/aistudio/PaddleSpeech/paddlespeech/vector/io/signal_processing.py", line 40, in compute_amplitude
    out = wav_sum / lengths
TypeError: (InvalidType) Type promotion only support calculations between floating-point numbers and between complex and real numbers. But got different data type x: float32, y: int64. (at ../paddle/phi/common/type_promotion.h:234)

```

@zxcd @Liyulingyue @GreatV @enkilee @yinfan98 