### PR TITLE
fix enable the punctuation for asr, test=asr(#3631)

### DIFF
--- a/paddlespeech/server/engine/engine_pool.py
+++ b/paddlespeech/server/engine/engine_pool.py
@@ -30,8 +30,9 @@ def init_engine_pool(config) -> bool:
     global ENGINE_POOL
 
     for engine_and_type in config.engine_list:
-        engine = engine_and_type.split("_")[0]
-        engine_type = engine_and_type.split("_")[1]
+        engine, engine_type = engine_and_type.split("_")
+        assert (engine != 'asr') or ('text_python' in config.engine_list), \
+            "When engine is 'asr', must be enabled 'text_python' to support punctuation recovery"
         ENGINE_POOL[engine] = EngineFactory.get_engine(
             engine_name=engine, engine_type=engine_type)
 

--- a/paddlespeech/server/restful/asr_api.py
+++ b/paddlespeech/server/restful/asr_api.py
@@ -20,13 +20,13 @@ from fastapi import APIRouter
 
 from paddlespeech.cli.log import logger
 from paddlespeech.server.engine.engine_pool import get_engine_pool
+from paddlespeech.server.engine.text.python.text_engine import PaddleTextConnectionHandler
 from paddlespeech.server.restful.request import ASRRequest
 from paddlespeech.server.restful.response import ASRResponse
 from paddlespeech.server.restful.response import ErrorResponse
 from paddlespeech.server.utils.errors import ErrorCode
 from paddlespeech.server.utils.errors import failed_response
 from paddlespeech.server.utils.exception import ServerBaseException
-from paddlespeech.server.engine.text.python.text_engine import PaddleTextConnectionHandler
 
 router = APIRouter()
 

--- a/paddlespeech/server/restful/asr_api.py
+++ b/paddlespeech/server/restful/asr_api.py
@@ -26,6 +26,7 @@ from paddlespeech.server.restful.response import ErrorResponse
 from paddlespeech.server.utils.errors import ErrorCode
 from paddlespeech.server.utils.errors import failed_response
 from paddlespeech.server.utils.exception import ServerBaseException
+from paddlespeech.server.engine.text.python.text_engine import PaddleTextConnectionHandler
 
 router = APIRouter()
 
@@ -82,6 +83,11 @@ def asr(request_body: ASRRequest):
 
         connection_handler.run(audio_data)
         asr_results = connection_handler.postprocess()
+
+        if request_body.punc:
+            text_engine = engine_pool['text']
+            connection_handler = PaddleTextConnectionHandler(text_engine)
+            asr_results = connection_handler.run(asr_results)
 
         response = {
             "success": True,


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others 

### Describe
修复在ASR服务接口中传入参数punc:true不生效的问题：
{ "audio": base64_string, "audio_format": "wav", "sample_rate": 32000, "lang": "zh_cn", "punc": True }
经过排查确认原因是text_python被抽离出来做了单独服务，并没有在asr服务中使用，也就是说在asr接口中并没有判断和使用到punc参数。
我修改代码在ASR接口中增加了punc参数判断和text_python引擎调用的代码，并在服务启动ening_init时检查和确保asr任务必须启用text_python引擎
