### PR TITLE
[Hackathon 7th] fix example led_en_zh st1

### DIFF
--- a/examples/ted_en_zh/st1/local/data.sh
+++ b/examples/ted_en_zh/st1/local/data.sh
@@ -203,7 +203,7 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     echo "stage 3: Format the Json Data"
     for (( i=0; i<${#x[*]}; ++i)); do
         python3 ${MAIN_ROOT}/utils/espnet_json_to_manifest.py \
-         --json-file ${x[$i]}/data_${bpemode}${nbpe}.json 
+         --json-file ${x[$i]}/data_${bpemode}${nbpe}.json \
          --manifest-file data/manifest.${y[$i]}
     done
 fi

--- a/utils/addjson.py
+++ b/utils/addjson.py
@@ -11,8 +11,6 @@ import json
 import logging
 import sys
 
-from espnet.utils.cli_utils import get_commandline_args
-
 from paddlespeech.utils.argparse import strtobool
 
 is_python2 = sys.version_info[0] == 2
@@ -44,7 +42,7 @@ if __name__ == "__main__":
         logging.basicConfig(level=logging.INFO, format=logfmt)
     else:
         logging.basicConfig(level=logging.WARN, format=logfmt)
-    logging.info(get_commandline_args())
+    logging.info(args)
 
     # make intersection set for utterance keys
     js = []


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
This pull request includes changes to improve the handling of JSON data and logging within the `examples/ted_en_zh/st1/local/data.sh` and `utils/addjson.py` files. The most important changes include updating the JSON data formatting script and modifying the logging mechanism.

Improvements to JSON data handling:

* [`examples/ted_en_zh/st1/local/data.sh`](diffhunk://#diff-36435057864b160898da23ff2e264c2cf0b37fc05abcfd1c5c359c5f998d353eL206-R206): Added a missing backslash to properly format the JSON data by ensuring the command continues on the next line.

Codebase simplification and logging improvements:

* [`utils/addjson.py`](diffhunk://#diff-0d5180cec4b05926385a02a508c6b3dd987279b32080c3010056a614cc9d2e0bL14-L15): Removed the import of `get_commandline_args` from `espnet.utils.cli_utils` as it was no longer used.
* [`utils/addjson.py`](diffhunk://#diff-0d5180cec4b05926385a02a508c6b3dd987279b32080c3010056a614cc9d2e0bL47-R45): Updated the logging to use `args` instead of `get_commandline_args()` to streamline the logging process.