### PR TITLE
【Hackathon 8th No.7】Python版本适配 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,25 @@ HERE = Path(os.path.abspath(os.path.dirname(__file__)))
 VERSION = '0.0.0'
 COMMITID = 'none'
 
+
+def determine_opencc_version():
+    # get gcc version
+    gcc_version = None
+    try:
+        output = sp.check_output(
+            ['gcc', '--version'], stderr=sp.STDOUT, text=True)
+        for line in output.splitlines():
+            if "gcc" in line:
+                gcc_version = line.split()[-1]
+    except Exception as e:
+        gcc_version = None
+
+    # determine opencc version
+    if gcc_version and gcc_version.startswith("9."):
+        return "opencc==1.1.6"  # GCC 9 need opencc==1.1.6
+    return "opencc"  # default
+
+
 base = [
     "braceexpand",
     "editdistance",
@@ -48,7 +67,7 @@ base = [
     "matplotlib<=3.8.4",
     "nara_wpe",
     "onnxruntime>=1.11.0",
-    "opencc==1.1.6",
+    determine_opencc_version(),  # opencc or opencc==1.1.6
     "opencc-python-reimplemented",
     "pandas",
     "paddleaudio>=1.1.0",

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,9 @@ def determine_opencc_version():
         gcc_version = None
 
     # determine opencc version
-    if gcc_version and gcc_version.startswith("9."):
-        return "opencc==1.1.6"  # GCC 9 need opencc==1.1.6
+    if gcc_version:
+        if int(gcc_version.split(".")[0]) <= 9:
+            return "opencc==1.1.6"  # GCC<=9 need opencc==1.1.6
     return "opencc"  # default
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
取消opencc==1.1.6的依赖，opencc仅作用于paddlespeech/t2s/frontend/g2pw/onnx_api.py，但版本强依赖导致无法安装paddlespeech。取消后，未见import模块异常。由于CI环境和Aistudio环境不支持gcc10，增加逻辑判断。