### PR TITLE
【Hackathon 8th No.7】Python版本适配 3

### DIFF
--- a/examples/other/g2p/get_g2p_data.py
+++ b/examples/other/g2p/get_g2p_data.py
@@ -32,7 +32,7 @@ def get_baker_data(root_dir):
             alignment_fp, includeEmptyIntervals=True)
         # only with baker's annotation
         utt_id = alignment.tierNameList[0].split(".")[0]
-        intervals = alignment.getTier(alignment.tierNameList[0]).entryList
+        intervals = alignment.getTier(alignment.tierNameList[0]).entries
         phones = []
         for interval in intervals:
             label = interval.label

--- a/examples/other/g2p/get_g2p_data.py
+++ b/examples/other/g2p/get_g2p_data.py
@@ -32,7 +32,7 @@ def get_baker_data(root_dir):
             alignment_fp, includeEmptyIntervals=True)
         # only with baker's annotation
         utt_id = alignment.tierNameList[0].split(".")[0]
-        intervals = alignment.tierDict[alignment.tierNameList[0]].entryList
+        intervals = alignment.getTier(alignment.tierNameList[0]).entryList
         phones = []
         for interval in intervals:
             label = interval.label

--- a/paddlespeech/server/restful/request.py
+++ b/paddlespeech/server/restful/request.py
@@ -65,7 +65,7 @@ class TTSRequest(BaseModel):
     speed: float = 1.0
     volume: float = 1.0
     sample_rate: int = 0
-    save_path: str = None
+    save_path: Optional[str] = None
 
 
 #****************************************************************************************/

--- a/paddlespeech/server/restful/response.py
+++ b/paddlespeech/server/restful/response.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import List
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -62,7 +63,7 @@ class TTSResult(BaseModel):
     volume: float = 1.0
     sample_rate: int
     duration: float
-    save_path: str = None
+    save_path: Optional[str] = None
     audio: str
 
 

--- a/paddlespeech/t2s/exps/ernie_sat/align.py
+++ b/paddlespeech/t2s/exps/ernie_sat/align.py
@@ -41,11 +41,11 @@ def _readtg(tg_path: str, lang: str='en', fs: int=24000, n_shift: int=300):
     ends = []
     words = []
 
-    for interval in alignment.tierDict['words'].entryList:
+    for interval in alignment.getTier('words').entries:
         word = interval.label
         if word:
             words.append(word)
-    for interval in alignment.tierDict['phones'].entryList:
+    for interval in alignment.getTier('phones').entries:
         phone = interval.label
         phones.append(phone)
         ends.append(interval.end)

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ base = [
     "paddleslim>=2.3.4",
     "ppdiffusers>=0.9.0",
     "paddlespeech_feat",
-    "praatio",
+    "praatio>=6.0.0",
     "prettytable",
     "pydantic",
     "pypinyin",

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ base = [
     "ToJyutping==0.2.1",
     "typeguard==2.13.3",
     "webrtcvad",
-    "yacs",
+    "yacs~=0.1.8",
     "zhon",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ base = [
     "praatio>=6.0.0",
     "prettytable",
     "pydantic",
-    "pypinyin",
+    "pypinyin<=0.44.0",
     "pypinyin-dict",
     "python-dateutil",
     "pyworld>=0.2.12",

--- a/setup.py
+++ b/setup.py
@@ -56,10 +56,10 @@ base = [
     "paddleslim>=2.3.4",
     "ppdiffusers>=0.9.0",
     "paddlespeech_feat",
-    "praatio>=5.0.0, <=5.1.1",
+    "praatio",
     "prettytable",
-    "pydantic>=1.10.14, <2.0",
-    "pypinyin<=0.44.0",
+    "pydantic",
+    "pypinyin",
     "pypinyin-dict",
     "python-dateutil",
     "pyworld>=0.2.12",
@@ -72,7 +72,7 @@ base = [
     "ToJyutping==0.2.1",
     "typeguard==2.13.3",
     "webrtcvad",
-    "yacs~=0.1.8",
+    "yacs",
     "zhon",
 ]
 

--- a/utils/gen_duration_from_textgrid.py
+++ b/utils/gen_duration_from_textgrid.py
@@ -26,7 +26,7 @@ def readtg(tg_path, sample_rate=24000, n_shift=300):
     alignment = textgrid.openTextgrid(tg_path, includeEmptyIntervals=True)
     phones = []
     ends = []
-    for interval in alignment.tierDict["phones"].entryList:
+    for interval in alignment.getTier("phones").entries:
         phone = interval.label
         phones.append(phone)
         ends.append(interval.end)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
移除对部分依赖库的版本限制

基于 https://github.com/timmahrt/praatIO/blob/main/UPGRADING.md#version-5-to-6-migration
- Instead of using with Textgrid.tierDict directly, please use Textgrid.addTier(), Textgrid.getTier(), Textgrid.removeTier(), and Textgrid.renameTier()
- TextgridTier.entryList was renamed to TextgridTier.entries and made read only. Please use TextgridTier.insertEntry() and TextgridTier.deleteEntry() if you need to modify it.