### PR TITLE
【PaddleSpeech No.6】补全合成系列中的脚本中参数缺失

### DIFF
--- a/examples/canton/tts3/README.md
+++ b/examples/canton/tts3/README.md
@@ -37,6 +37,7 @@ Run the command below to
 3. train the model.
 4. synthesize wavs.
     - synthesize waveform from `metadata.jsonl`.
+    - `--stage` controls the vocoder model during synthesis (0 = pwgan, 1 = hifigan).
     - synthesize waveform from text file.
 ```bash
 ./run.sh

--- a/examples/canton/tts3/run.sh
+++ b/examples/canton/tts3/run.sh
@@ -29,12 +29,12 @@ fi
 
 if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
     # synthesize, vocoder is pwgan by default
-    CUDA_VISIBLE_DEVICES=${gpus} ./local/synthesize.sh ${conf_path} ${train_output_path} ${ckpt_name} || exit -1
+    CUDA_VISIBLE_DEVICES=${gpus} ./local/synthesize.sh --stage 0 ${conf_path} ${train_output_path} ${ckpt_name} || exit -1
 fi
 
 if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     # synthesize_e2e, vocoder is pwgan by default
-    CUDA_VISIBLE_DEVICES=${gpus} ./local/synthesize_e2e.sh ${conf_path} ${train_output_path} ${ckpt_name} || exit -1
+    CUDA_VISIBLE_DEVICES=${gpus} ./local/synthesize_e2e.sh --stage 0 ${conf_path} ${train_output_path} ${ckpt_name} || exit -1
 fi
 
 if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then

--- a/examples/canton/tts3/run.sh
+++ b/examples/canton/tts3/run.sh
@@ -28,12 +28,12 @@ if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
 fi
 
 if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
-    # synthesize, vocoder is pwgan by default
+    # synthesize, vocoder is pwgan by default stage 0, stage 1 will use hifigan as vocoder
     CUDA_VISIBLE_DEVICES=${gpus} ./local/synthesize.sh --stage 0 ${conf_path} ${train_output_path} ${ckpt_name} || exit -1
 fi
 
 if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
-    # synthesize_e2e, vocoder is pwgan by default
+    # synthesize_e2e, vocoder is pwgan by default stage 0, stage 1 will use hifigan as vocoder
     CUDA_VISIBLE_DEVICES=${gpus} ./local/synthesize_e2e.sh --stage 0 ${conf_path} ${train_output_path} ${ckpt_name} || exit -1
 fi
 

--- a/examples/csmsc/voc3/README.md
+++ b/examples/csmsc/voc3/README.md
@@ -86,7 +86,7 @@ Download pretrained MultiBand MelGAN model from [mb_melgan_csmsc_ckpt_0.1.1.zip]
 ```bash
 unzip mb_melgan_csmsc_ckpt_0.1.1.zip
 ```
-HiFiGAN checkpoint contains files listed below.
+MultiBand MelGAN checkpoint contains files listed below.
 ```text
 mb_melgan_csmsc_ckpt_0.1.1
 ├── default.yaml                    # default config used to train MultiBand MelGAN

--- a/examples/csmsc/voc3/README.md
+++ b/examples/csmsc/voc3/README.md
@@ -86,7 +86,7 @@ Download pretrained MultiBand MelGAN model from [mb_melgan_csmsc_ckpt_0.1.1.zip]
 ```bash
 unzip mb_melgan_csmsc_ckpt_0.1.1.zip
 ```
-MultiBand MelGAN checkpoint contains files listed below.
+HiFiGAN checkpoint contains files listed below.
 ```text
 mb_melgan_csmsc_ckpt_0.1.1
 ├── default.yaml                    # default config used to train MultiBand MelGAN


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Function optimization, Docs

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

Docs, Others

### Describe
<!-- Describe what this PR does -->
本次修改主要包含：

1. **脚本优化**：为 `run.sh` 中的合成阶段添加 `--stage` 参数。

2. **文档完善**：在 README.md 中补充 stage 参数说明，明确 vocoder 选择逻辑。

4. Issue链接：https://github.com/PaddlePaddle/PaddleSpeech/issues/3997

@luotao1  @zxcd 
