### PR TITLE
【PaddleSpeech No.15】补全合成系列中的脚本中参数缺失

### DIFF
--- a/examples/csmsc/voc3/README.md
+++ b/examples/csmsc/voc3/README.md
@@ -86,7 +86,7 @@ Download pretrained MultiBand MelGAN model from [mb_melgan_csmsc_ckpt_0.1.1.zip]
 ```bash
 unzip mb_melgan_csmsc_ckpt_0.1.1.zip
 ```
-HiFiGAN checkpoint contains files listed below.
+MultiBand MelGAN checkpoint contains files listed below.
 ```text
 mb_melgan_csmsc_ckpt_0.1.1
 ├── default.yaml                    # default config used to train MultiBand MelGAN


### PR DESCRIPTION
PR types
Others

PR changes
Docs

Describe
补全合成系列中的脚本中参数缺失 No.5
修改：
`examples/csmsc/voc3/README.md`