### PR TITLE
【PaddleSpeech No.12】补全合成系列中的脚本中参数缺失

### DIFF
--- a/examples/csmsc/voc3/README.md
+++ b/examples/csmsc/voc3/README.md
@@ -86,7 +86,7 @@ Download pretrained MultiBand MelGAN model from [mb_melgan_csmsc_ckpt_0.1.1.zip]
 ```bash
 unzip mb_melgan_csmsc_ckpt_0.1.1.zip
 ```
-HiFiGAN checkpoint contains files listed below.
+MultiBand MelGAN checkpoint contains files listed below.
 ```text
 mb_melgan_csmsc_ckpt_0.1.1
 ├── default.yaml                    # default config used to train MultiBand MelGAN

--- a/examples/csmsc/voc3/README.md
+++ b/examples/csmsc/voc3/README.md
@@ -141,8 +141,10 @@ fastspeech2_nosil_baker_ckpt_0.4
 
 `./local/synthesize_e2e.sh` calls `${BIN_DIR}/../../synthesize_e2e.py`, which can synthesize waveform from text file.
 ```bash
-CUDA_VISIBLE_DEVICES=${gpus} ./local/synthesize_e2e.sh ${conf_path} ${train_output_path} ${ckpt_name}
+CUDA_VISIBLE_DEVICES=${gpus} ./local/synthesize_e2e.sh --stage 0 ${conf_path} ${train_output_path} ${ckpt_name}
 ```
+`--stage` controls the vocoder model during synthesis, which can be `0` or `1`, use `pwgan` or `hifigan` model as vocoder.
+
 ```text
 usage: synthesize_e2e.py [-h]
                          [--am {speedyspeech_csmsc,speedyspeech_aishell3,fastspeech2_csmsc,fastspeech2_ljspeech,fastspeech2_aishell3,fastspeech2_vctk,tacotron2_csmsc,tacotron2_ljspeech}]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization, Docs
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Docs, Others
### Describe
<!-- Describe what this PR does -->
本次修改主要包含：

对 examples/opencpop/svs1的READEME.md、README_cn.md、run.sh脚本均进行修改。

脚本优化： 为 run.sh 中的合成阶段添加 --stage 参数，支持通过0/1选择 PWGAN/HiFiGAN 作为声码器；在 synthesize.sh 和 synthesize_e2e.sh 中实现多声码器切换逻辑

文档完善： 在 README.md 和中文文档中均补充 stage 参数说明，明确 vocoder 选择逻辑。

Issue链接：https://github.com/PaddlePaddle/PaddleSpeech/issues/3997

@luotao1 @zxcd