### PR TITLE
Bug fix librosa.resample

### DIFF
--- a/paddlespeech/server/engine/tts/python/tts_engine.py
+++ b/paddlespeech/server/engine/tts/python/tts_engine.py
@@ -147,7 +147,7 @@ class PaddleTTSConnectionHandler(TTSServerExecutor):
                 format(original_fs))
         else:
             wav_tar_fs = librosa.resample(
-                np.squeeze(wav), original_fs, target_fs)
+                np.squeeze(wav), orig_sr=original_fs, target_sr=target_fs)
             logger.debug(
                 "The sample rate of model is {}Hz and the target sample rate is {}Hz. Converting the sample rate of the synthesized audio successfully.".
                 format(original_fs, target_fs))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
APIs

### Describe
TTS - tts_engine

bug fix when using librosa>=0.9.0 will show:
```
    wav_tar_fs = librosa.resample(
TypeError: resample() takes 1 positional argument but 3 were given
``` 
![图片](https://github.com/user-attachments/assets/804f02d2-68e4-4462-bfc9-6ac107ac71d0)

