### PR TITLE
Add missing installation of paddlepaddle

### DIFF
--- a/docs/tutorial/asr/tutorial_deepspeech2.ipynb
+++ b/docs/tutorial/asr/tutorial_deepspeech2.ipynb
@@ -265,7 +265,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install --upgrade pip && pip install paddlespeech paddlepaddle"
+    "!pip install -U pip paddlepaddle && pip install paddlespeech"
    ]
   },
   {

--- a/docs/tutorial/asr/tutorial_deepspeech2.ipynb
+++ b/docs/tutorial/asr/tutorial_deepspeech2.ipynb
@@ -265,7 +265,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -U pip paddlepaddle && pip install paddlespeech"
+    "!pip install -U pip paddlepaddle-gpu && pip install paddlespeech"
    ]
   },
   {

--- a/docs/tutorial/asr/tutorial_deepspeech2.ipynb
+++ b/docs/tutorial/asr/tutorial_deepspeech2.ipynb
@@ -265,7 +265,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install --upgrade pip && pip install paddlespeech==0.1.0"
+    "!pip install --upgrade pip && pip install paddlespeech paddlepaddle"
    ]
   },
   {

--- a/docs/tutorial/asr/tutorial_transformer.ipynb
+++ b/docs/tutorial/asr/tutorial_transformer.ipynb
@@ -138,7 +138,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install --upgrade pip && pip install paddlespeech==0.1.0"
+    "!pip install --upgrade pip && pip install paddlespeech paddlepaddle"
    ]
   },
   {

--- a/docs/tutorial/asr/tutorial_transformer.ipynb
+++ b/docs/tutorial/asr/tutorial_transformer.ipynb
@@ -138,7 +138,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install --upgrade pip && pip install paddlespeech paddlepaddle"
+    "!pip install -U pip paddlepaddle && pip install paddlespeech"
    ]
   },
   {

--- a/docs/tutorial/asr/tutorial_transformer.ipynb
+++ b/docs/tutorial/asr/tutorial_transformer.ipynb
@@ -138,7 +138,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -U pip paddlepaddle && pip install paddlespeech"
+    "!pip install -U pip paddlepaddle-gpu && pip install paddlespeech"
    ]
   },
   {

--- a/docs/tutorial/cls/cls_tutorial.ipynb
+++ b/docs/tutorial/cls/cls_tutorial.ipynb
@@ -53,7 +53,7 @@
    "outputs": [],
    "source": [
     "# 环境准备：安装paddlespeech\n",
-    "!pip install --upgrade pip && pip install paddlespeech -U"
+    "!pip install -U pip paddlepaddle && pip install paddlespeech"
    ]
   },
   {

--- a/docs/tutorial/cls/cls_tutorial.ipynb
+++ b/docs/tutorial/cls/cls_tutorial.ipynb
@@ -53,7 +53,7 @@
    "outputs": [],
    "source": [
     "# 环境准备：安装paddlespeech\n",
-    "!pip install -U pip paddlepaddle && pip install paddlespeech"
+    "!pip install -U pip paddlepaddle-gpu && pip install paddlespeech"
    ]
   },
   {

--- a/docs/tutorial/st/st_tutorial.ipynb
+++ b/docs/tutorial/st/st_tutorial.ipynb
@@ -138,8 +138,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -U pip\n",
-    "!pip install paddlespeech"
+    "!pip install -U pip paddlepaddle && pip install paddlespeech"
    ]
   },
   {

--- a/docs/tutorial/st/st_tutorial.ipynb
+++ b/docs/tutorial/st/st_tutorial.ipynb
@@ -138,7 +138,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -U pip paddlepaddle && pip install paddlespeech"
+    "!pip install -U pip paddlepaddle-gpu && pip install paddlespeech"
    ]
   },
   {

--- a/docs/tutorial/tts/tts_tutorial.ipynb
+++ b/docs/tutorial/tts/tts_tutorial.ipynb
@@ -158,7 +158,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade pip && pip install paddlespeech -U"
+    "!pip install -U pip paddlepaddle && pip install paddlespeech"
    ]
   },
   {

--- a/docs/tutorial/tts/tts_tutorial.ipynb
+++ b/docs/tutorial/tts/tts_tutorial.ipynb
@@ -158,7 +158,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -U pip paddlepaddle && pip install paddlespeech"
+    "!pip install -U pip paddlepaddle-gpu && pip install paddlespeech"
    ]
   },
   {


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
Hi.
This MR fixes two notebooks
* [tutorial_transformer.ipynb](https://colab.research.google.com/github/PaddlePaddle/PaddleSpeech/blob/master/docs/tutorial/asr/tutorial_transformer.ipynb)
* [tutorial_deepspeech2.ipynb](https://colab.research.google.com/github/PaddlePaddle/PaddleSpeech/blob/master/docs/tutorial/asr/tutorial_deepspeech2.ipynb)
by
* removing version of `paddlespeech`
```python
!pip install --upgrade pip && pip install paddlespeech==0.1.0

Requirement already satisfied: pip in /usr/local/lib/python3.12/dist-packages (24.1.2)
Collecting pip
  Downloading pip-25.2-py3-none-any.whl.metadata (4.7 kB)
Downloading pip-25.2-py3-none-any.whl (1.8 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.8/1.8 MB 17.0 MB/s eta 0:00:00
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 24.1.2
    Uninstalling pip-24.1.2:
      Successfully uninstalled pip-24.1.2
Successfully installed pip-25.2
Collecting paddlespeech==0.1.0
  Downloading paddlespeech-0.1.0-py3-none-any.whl.metadata (24 kB)
Requirement already satisfied: editdistance in /usr/local/lib/python3.12/dist-packages (from paddlespeech==0.1.0) (0.8.1)
Collecting g2p-en (from paddlespeech==0.1.0)
  Downloading g2p_en-2.1.0-py3-none-any.whl.metadata (4.5 kB)
Collecting g2pM (from paddlespeech==0.1.0)
  Downloading g2pM-0.1.2.5-py3-none-any.whl.metadata (4.0 kB)
Requirement already satisfied: h5py in /usr/local/lib/python3.12/dist-packages (from paddlespeech==0.1.0) (3.14.0)
Requirement already satisfied: inflect in /usr/local/lib/python3.12/dist-packages (from paddlespeech==0.1.0) (7.5.0)
Requirement already satisfied: jieba in /usr/local/lib/python3.12/dist-packages (from paddlespeech==0.1.0) (0.42.1)
Collecting jsonlines (from paddlespeech==0.1.0)
  Downloading jsonlines-4.0.0-py3-none-any.whl.metadata (1.6 kB)
Collecting kaldiio (from paddlespeech==0.1.0)
  Downloading kaldiio-2.18.1-py3-none-any.whl.metadata (13 kB)
Requirement already satisfied: librosa in /usr/local/lib/python3.12/dist-packages (from paddlespeech==0.1.0) (0.11.0)
Collecting loguru (from paddlespeech==0.1.0)
  Downloading loguru-0.7.3-py3-none-any.whl.metadata (22 kB)
Requirement already satisfied: matplotlib in /usr/local/lib/python3.12/dist-packages (from paddlespeech==0.1.0) (3.10.0)
Collecting nara-wpe (from paddlespeech==0.1.0)
  Downloading nara_wpe-0.0.11-py3-none-any.whl.metadata (6.1 kB)
Requirement already satisfied: nltk in /usr/local/lib/python3.12/dist-packages (from paddlespeech==0.1.0) (3.9.1)
Requirement already satisfied: pandas in /usr/local/lib/python3.12/dist-packages (from paddlespeech==0.1.0) (2.2.2)
Collecting paddleaudio (from paddlespeech==0.1.0)
  Downloading paddleaudio-1.0.2-py3-none-any.whl.metadata (852 bytes)
Collecting paddlespeech-feat (from paddlespeech==0.1.0)
  Downloading paddlespeech_feat-0.1.0-py3-none-any.whl.metadata (379 bytes)
Collecting praatio==5.0.0 (from paddlespeech==0.1.0)
  Downloading praatio-5.0.0-py3-none-any.whl.metadata (7.7 kB)
Collecting pypinyin (from paddlespeech==0.1.0)
  Downloading pypinyin-0.55.0-py2.py3-none-any.whl.metadata (12 kB)
Requirement already satisfied: python-dateutil in /usr/local/lib/python3.12/dist-packages (from paddlespeech==0.1.0) (2.9.0.post0)
Collecting pyworld (from paddlespeech==0.1.0)
  Downloading pyworld-0.3.5.tar.gz (261 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting resampy==0.2.2 (from paddlespeech==0.1.0)
  Downloading resampy-0.2.2.tar.gz (323 kB)
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  Preparing metadata (setup.py) ... error
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```
* add missing installatioon of `paddlepaddle`
<img width="1216" height="457" alt="image" src="https://github.com/user-attachments/assets/88e047ae-c9a7-4e78-b8f2-4998f3ee0c51" />

