### PR TITLE
fix: replace 9 bare except clauses with except Exception

### DIFF
--- a/examples/librispeech/asr5/compute_wer.py
+++ b/examples/librispeech/asr5/compute_wer.py
@@ -365,7 +365,7 @@ def main():
             verbose = 0
             try:
                 verbose = int(b)
-            except:
+            except Exception:
                 if b == 'true' or b != '0':
                     verbose = 1
             continue

--- a/examples/opencpop/voc5/local/prepare_env.py
+++ b/examples/opencpop/voc5/local/prepare_env.py
@@ -1,1 +1,62 @@
-../../../other/tts_finetune/tts3/local/prepare_env.py
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import os
+from pathlib import Path
+
+
+def generate_finetune_env(output_dir: Path, pretrained_model_dir: Path):
+
+    output_dir = output_dir / "checkpoints/"
+    output_dir = output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    model_path = sorted(list((pretrained_model_dir).rglob("*.pdz")))[0]
+    model_path = model_path.resolve()
+    iter = int(str(model_path).split("_")[-1].split(".")[0])
+    model_file = str(model_path).split("/")[-1]
+
+    os.system("cp %s %s" % (model_path, output_dir))
+
+    records_file = output_dir / "records.jsonl"
+    with open(records_file, "w") as f:
+        line = "\"time\": \"2022-08-06 07:51:53.463650\", \"path\": \"%s\", \"iteration\": %d" % (
+            str(output_dir / model_file), iter)
+        f.write("{" + line + "}" + "\n")
+
+
+if __name__ == '__main__':
+    # parse config and args
+    parser = argparse.ArgumentParser(
+        description="Preprocess audio and then extract features.")
+
+    parser.add_argument(
+        "--pretrained_model_dir",
+        type=str,
+        default="./pretrained_models/fastspeech2_aishell3_ckpt_1.1.0",
+        help="Path to pretrained model")
+
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="./exp/default/",
+        help="directory to save finetune model.")
+
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    pretrained_model_dir = Path(args.pretrained_model_dir).expanduser()
+
+    generate_finetune_env(output_dir, pretrained_model_dir)

--- a/paddlespeech/audiotools/core/util.py
+++ b/paddlespeech/audiotools/core/util.py
@@ -188,7 +188,7 @@ def info(audio_path: str):
     try:
         info = soundfile.info(str(audio_path))
         info = Info(sample_rate=info.samplerate, num_frames=info.frames)
-    except:
+    except Exception:
         info = info_ffmpeg(str(audio_path))
 
     return info
@@ -290,12 +290,12 @@ def _close_temp_files(tmpfiles: list):
             try:
                 t.close()
                 os.unlink(t.name)
-            except:
+            except Exception:
                 pass
 
     try:
         yield
-    except:
+    except Exception:
         _close()
         raise
     _close()
@@ -462,7 +462,7 @@ def prepare_batch(batch: typing.Union[dict, list, paddle.Tensor],
             try:
                 # batch[key] = val.to(device)
                 batch[key] = move_to_device(val, device)
-            except:
+            except Exception:
                 pass
         batch = unflatten(batch)
     elif paddle.is_tensor(batch):
@@ -472,7 +472,7 @@ def prepare_batch(batch: typing.Union[dict, list, paddle.Tensor],
         for i in range(len(batch)):
             try:
                 batch[i] = batch[i].to(device)
-            except:
+            except Exception:
                 pass
     return batch
 

--- a/paddlespeech/audiotools/data/datasets.py
+++ b/paddlespeech/audiotools/data/datasets.py
@@ -88,7 +88,7 @@ class AudioLoader:
         if source_idx is not None and item_idx is not None:
             try:
                 audio_info = self.audio_lists[source_idx][item_idx]
-            except:
+            except Exception:
                 audio_info = {"path": "none"}
         elif global_idx is not None:
             source_idx, item_idx = self.audio_indices[global_idx %

--- a/paddlespeech/dataset/s2t/compute_wer.py
+++ b/paddlespeech/dataset/s2t/compute_wer.py
@@ -365,7 +365,7 @@ def main():
             verbose = 0
             try:
                 verbose = int(b)
-            except:
+            except Exception:
                 if b == 'true' or b != '0':
                     verbose = 1
             continue

--- a/paddlespeech/s2t/exps/deepspeech2/model.py
+++ b/paddlespeech/s2t/exps/deepspeech2/model.py
@@ -338,7 +338,7 @@ class DeepSpeech2Tester(DeepSpeech2Trainer):
         static_model = infer_model.export()
         try:
             logger.info(f"Export code: {static_model.forward.code}")
-        except:
+        except Exception:
             logger.info(
                 f"Fail to print Export code, static_model.forward.code can not be run."
             )

--- a/paddlespeech/t2s/exps/tacotron2/normalize.py
+++ b/paddlespeech/t2s/exps/tacotron2/normalize.py
@@ -1,1 +1,124 @@
-../transformer_tts/normalize.py
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Normalize feature files and dump them."""
+import argparse
+import logging
+from operator import itemgetter
+from pathlib import Path
+
+import jsonlines
+import numpy as np
+from sklearn.preprocessing import StandardScaler
+from tqdm import tqdm
+
+from paddlespeech.t2s.datasets.data_table import DataTable
+
+
+def main():
+    """Run preprocessing process."""
+    parser = argparse.ArgumentParser(
+        description="Normalize dumped raw features (See detail in parallel_wavegan/bin/normalize.py)."
+    )
+    parser.add_argument(
+        "--metadata",
+        type=str,
+        required=True,
+        help="directory including feature files to be normalized. "
+        "you need to specify either *-scp or rootdir.")
+
+    parser.add_argument(
+        "--dumpdir",
+        type=str,
+        required=True,
+        help="directory to dump normalized feature files.")
+    parser.add_argument(
+        "--speech-stats",
+        type=str,
+        required=True,
+        help="speech statistics file.")
+    parser.add_argument(
+        "--phones-dict", type=str, default=None, help="phone vocabulary file.")
+    parser.add_argument(
+        "--speaker-dict", type=str, default=None, help="speaker id map file.")
+
+    args = parser.parse_args()
+
+    # check directory existence
+    dumpdir = Path(args.dumpdir).resolve()
+    dumpdir.mkdir(parents=True, exist_ok=True)
+
+    # get dataset
+    with jsonlines.open(args.metadata, 'r') as reader:
+        metadata = list(reader)
+    dataset = DataTable(
+        metadata, converters={
+            "speech": np.load,
+        })
+    logging.info(f"The number of files = {len(dataset)}.")
+
+    # restore scaler
+    speech_scaler = StandardScaler()
+    speech_scaler.mean_ = np.load(args.speech_stats)[0]
+    speech_scaler.scale_ = np.load(args.speech_stats)[1]
+    speech_scaler.n_features_in_ = speech_scaler.mean_.shape[0]
+
+    vocab_phones = {}
+    with open(args.phones_dict, 'rt') as f:
+        phn_id = [line.strip().split() for line in f.readlines()]
+    for phn, id in phn_id:
+        vocab_phones[phn] = int(id)
+
+    vocab_speaker = {}
+    with open(args.speaker_dict, 'rt') as f:
+        spk_id = [line.strip().split() for line in f.readlines()]
+    for spk, id in spk_id:
+        vocab_speaker[spk] = int(id)
+
+    # process each file
+    output_metadata = []
+
+    for item in tqdm(dataset):
+        utt_id = item['utt_id']
+        speech = item['speech']
+        # normalize
+        speech = speech_scaler.transform(speech)
+        speech_dir = dumpdir / "data_speech"
+        speech_dir.mkdir(parents=True, exist_ok=True)
+        speech_path = speech_dir / f"{utt_id}_speech.npy"
+        np.save(speech_path, speech.astype(np.float32), allow_pickle=False)
+
+        phone_ids = [vocab_phones[p] for p in item['phones']]
+        spk_id = vocab_speaker[item["speaker"]]
+        record = {
+            "utt_id": item['utt_id'],
+            "spk_id": spk_id,
+            "text": phone_ids,
+            "text_lengths": item['text_lengths'],
+            "speech_lengths": item['speech_lengths'],
+            "speech": str(speech_path),
+        }
+        # add spk_emb for voice cloning
+        if "spk_emb" in item:
+            record["spk_emb"] = str(item["spk_emb"])
+        output_metadata.append(record)
+    output_metadata.sort(key=itemgetter('utt_id'))
+    output_metadata_path = Path(args.dumpdir) / "metadata.jsonl"
+    with jsonlines.open(output_metadata_path, 'w') as writer:
+        for item in output_metadata:
+            writer.write(item)
+    logging.info(f"metadata dumped into {output_metadata_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What
Replace 9 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.