### PR TITLE
Remove duplicate keys in asr cfg

### DIFF
--- a/demos/streaming_asr_server/conf/application.yaml
+++ b/demos/streaming_asr_server/conf/application.yaml
@@ -27,7 +27,6 @@ asr_online:
     lang: 'zh'
     sample_rate: 16000
     cfg_path: 
-    decode_method: 
     num_decoding_left_chunks: -1
     force_yes: True
     device: 'cpu' # cpu or gpu:id

--- a/demos/streaming_asr_server/conf/ws_conformer_application.yaml
+++ b/demos/streaming_asr_server/conf/ws_conformer_application.yaml
@@ -27,7 +27,6 @@ asr_online:
     lang: 'zh'
     sample_rate: 16000
     cfg_path: 
-    decode_method: 
     num_decoding_left_chunks: -1
     force_yes: True
     device: 'cpu' # cpu or gpu:id

--- a/demos/streaming_asr_server/conf/ws_conformer_talcs_application.yaml
+++ b/demos/streaming_asr_server/conf/ws_conformer_talcs_application.yaml
@@ -28,7 +28,6 @@ asr_online:
     lang: 'zh_en'
     sample_rate: 16000
     cfg_path: 
-    decode_method: 
     num_decoding_left_chunks: -1
     force_yes: True
     device: 'cpu' # cpu or gpu:id

--- a/demos/streaming_asr_server/conf/ws_conformer_wenetspeech_application.yaml
+++ b/demos/streaming_asr_server/conf/ws_conformer_wenetspeech_application.yaml
@@ -27,7 +27,6 @@ asr_online:
     lang: 'zh'
     sample_rate: 16000
     cfg_path: 
-    decode_method: 
     force_yes: True
     device: 'cpu' # cpu or gpu:id
     decode_method: "attention_rescoring"

--- a/demos/streaming_asr_server/conf/ws_conformer_wenetspeech_application_faster.yaml
+++ b/demos/streaming_asr_server/conf/ws_conformer_wenetspeech_application_faster.yaml
@@ -27,7 +27,6 @@ asr_online:
     lang: 'zh'
     sample_rate: 16000
     cfg_path: 
-    decode_method: 
     force_yes: True
     device: 'cpu' # cpu or gpu:id
     decode_method: "attention_rescoring"

--- a/demos/streaming_asr_server/conf/ws_ds2_application.yaml
+++ b/demos/streaming_asr_server/conf/ws_ds2_application.yaml
@@ -44,7 +44,6 @@ asr_online-onnx:
 
     chunk_buffer_conf:
         frame_duration_ms: 85
-        shift_ms: 40
         sample_rate: 16000
         sample_width: 2
         window_n: 7     # frame
@@ -75,7 +74,6 @@ asr_online-inference:
 
     chunk_buffer_conf:
         frame_duration_ms: 85
-        shift_ms: 40
         sample_rate: 16000
         sample_width: 2
         window_n: 7     # frame

--- a/paddlespeech/server/conf/ws_conformer_wenetspeech_application_faster.yaml
+++ b/paddlespeech/server/conf/ws_conformer_wenetspeech_application_faster.yaml
@@ -27,7 +27,6 @@ asr_online:
     lang: 'zh'
     sample_rate: 16000
     cfg_path: 
-    decode_method: 
     force_yes: True
     device: 'cpu' # cpu or gpu:id
     decode_method: "attention_rescoring"

--- a/paddlespeech/server/conf/ws_ds2_application.yaml
+++ b/paddlespeech/server/conf/ws_ds2_application.yaml
@@ -44,7 +44,6 @@ asr_online-onnx:
 
     chunk_buffer_conf:
         frame_duration_ms: 85
-        shift_ms: 40
         sample_rate: 16000
         sample_width: 2
         window_n: 7     # frame
@@ -75,7 +74,6 @@ asr_online-inference:
 
     chunk_buffer_conf:
         frame_duration_ms: 85
-        shift_ms: 40
         sample_rate: 16000
         sample_width: 2
         window_n: 7     # frame


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
Removed duplicate keys in the `streaming_asr_server` configuration. For example, the `decode_method` key appeared twice in the configuration block. This duplication does not affect functionality but makes the config file less clean and could potentially cause confusion. This PR removes the redundant line to improve readability and maintain code hygiene. No functional changes are introduced.