### PR TITLE
Fix path traversal in tar/zip extraction

### DIFF
--- a/paddlespeech/cli/download.py
+++ b/paddlespeech/cli/download.py
@@ -250,6 +250,11 @@ def _uncompress_file_zip(filepath):
 
     file_dir = os.path.dirname(filepath)
 
+    for name in file_list:
+        if os.path.isabs(name) or '..' in name.split('/'):
+            raise ValueError(
+                "Path traversal detected in zip member: {}".format(name))
+
     if _is_a_single_file(file_list):
         rootpath = file_list[0]
         uncompressed_path = os.path.join(file_dir, rootpath)
@@ -280,6 +285,11 @@ def _uncompress_file_zip(filepath):
 def _uncompress_file_tar(filepath, mode="r:*"):
     files = tarfile.open(filepath, mode)
     file_list = files.getnames()
+
+    for name in file_list:
+        if os.path.isabs(name) or '..' in name.split('/'):
+            raise ValueError(
+                "Path traversal detected in tar member: {}".format(name))
 
     file_dir = os.path.dirname(filepath)
 


### PR DESCRIPTION
## Summary

`_uncompress_file_tar()` and `_uncompress_file_zip()` in `paddlespeech/cli/download.py` extract archive members using `tarfile.extract()` / `zipfile.extract()` with no path validation. A crafted archive containing `../` entries can write files outside the intended extraction directory.

This is especially relevant because dataset download URLs use plaintext HTTP (`http://www.openslr.org/`, `http://openslr.elda.org/`), making MITM injection of malicious archives feasible.

## Changes

- Validate all member names before extraction in both `_uncompress_file_tar()` and `_uncompress_file_zip()`
- Reject members with absolute paths or `..` path components

## Test

```python
import io, tarfile, tempfile
from pathlib import Path
from paddlespeech.cli.download import _uncompress_file_tar

tar_path = Path(tempfile.mkdtemp()) / "test.tar.gz"
with tarfile.open(str(tar_path), "w:gz") as tf:
    info = tarfile.TarInfo(name="../../../tmp/proof.txt")
    data = b"traversal\n"
    info.size = len(data)
    tf.addfile(info, io.BytesIO(data))

try:
    _uncompress_file_tar(str(tar_path))
    print("FAIL: no exception raised")
except ValueError as e:
    print(f"PASS: {e}")
```

Before fix: file written to `/tmp/proof.txt`
After fix: `ValueError: Path traversal detected in tar member: ../../../tmp/proof.txt`